### PR TITLE
Added null Check for Proxy command

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -586,9 +586,9 @@ param(
         [Parameter(Mandatory=$true)][string]$RegistryLocation
     )
         $connections = Get-ItemProperty -Path $RegistryLocation
-        if(($Connections | gm).Name -contains "WinHttpSettings")
+        $Proxy = [string]::Empty
+        if(($connections -ne $null) -and ($Connections | gm).Name -contains "WinHttpSettings")
         {
-            $Proxy = [string]::Empty
             foreach($Byte in $Connections.WinHttpSettings)
             {
                 if($Byte -ge 48)


### PR DESCRIPTION
Added the null check for proxy command for Windows 2019 Core, as we return a null value there.


Resolved #76 
