### PR TITLE
buildRevision improvement

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -2597,7 +2597,7 @@ param(
     #We check only for year 2018+ vulnerabilities
     #https://www.cvedetails.com/vulnerability-list/vendor_id-26/product_id-194/Microsoft-Exchange-Server.html 
 
-    [double]$buildRevision = [System.Convert]::ToDouble(("{0}.{1}" -f $HealthExSvrObj.ExchangeInformation.ExchangeSetup.FileBuildPart, $HealthExSvrObj.ExchangeInformation.ExchangeSetup.FilePrivatePart))
+    [double]$buildRevision = [System.Convert]::ToDouble(("{0}.{1}" -f $HealthExSvrObj.ExchangeInformation.ExchangeSetup.FileBuildPart, $HealthExSvrObj.ExchangeInformation.ExchangeSetup.FilePrivatePart), (New-Object System.Globalization.Cultureinfo(“”)))
     Write-VerboseOutput("Exchange Build Revision: {0}" -f $buildRevision) 
     Write-VerboseOutput("Exchange CU: {0}" -f ($exchangeCU = $HealthExSvrObj.ExchangeInformation.ExchangeBuildObject.CU))
 


### PR DESCRIPTION
This pull request will fix issue #130 . This pull request replaces pull #131 .
We use invariant culture to convert FileBuildPart and FilePrivatePart to double.
This is an better way instead of using a function to switch the culture on the thread.

Invariant culture:
An invariant culture is culture-insensitive. Your application specifies the invariant culture by name using an empty string ("") or by its identifier. InvariantCulture defines an instance of the invariant culture. It is associated with the English language but not with any country/region. It is used in almost any method in the Globalization namespace that requires a culture.