### PR TITLE
Problem with CultureInfo on another system

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -2597,7 +2597,7 @@ param(
     #We check only for year 2018+ vulnerabilities
     #https://www.cvedetails.com/vulnerability-list/vendor_id-26/product_id-194/Microsoft-Exchange-Server.html 
 
-    [double]$buildRevision = [System.Convert]::ToDouble(("{0}.{1}" -f $HealthExSvrObj.ExchangeInformation.ExchangeSetup.FileBuildPart, $HealthExSvrObj.ExchangeInformation.ExchangeSetup.FilePrivatePart), (New-Object System.Globalization.Cultureinfo(“”)))
+    [double]$buildRevision = [System.Convert]::ToDouble(("{0}.{1}" -f $HealthExSvrObj.ExchangeInformation.ExchangeSetup.FileBuildPart, $HealthExSvrObj.ExchangeInformation.ExchangeSetup.FilePrivatePart), [System.Globalization.CultureInfo]::InvariantCulture)
     Write-VerboseOutput("Exchange Build Revision: {0}" -f $buildRevision) 
     Write-VerboseOutput("Exchange CU: {0}" -f ($exchangeCU = $HealthExSvrObj.ExchangeInformation.ExchangeBuildObject.CU))
 


### PR DESCRIPTION
Hit an issue with New-Object System.Globalization.Cultureinfo(“”) on Server 2012 with Exchange 2013, .Net 4.7.1 and PowerShell 4.
I'm not sure (until yet) why this throw an error. [System.Globalization.CultureInfo]::InvariantCulture works properly. We should go this way to address issue #130