### PR TITLE
Visual C++ Redistributable Package Check

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -277,7 +277,6 @@ using System.Collections;
             Unknown = 0,
             VCRedist2012 = 184610406,
             VCRedist2013 = 201367252
-
         }
 
         public class VCRedistObject
@@ -842,8 +841,7 @@ param(
     $Return.vc2013Current = $false
 
     $DetectedVisualCRedistVersions = Get-VisualCRedistributableVersion -MachineName $ExchangeServerObj.ServerName
-
-    ## ToDo: isnullorempty
+    
     if($DetectedVisualCRedistVersions -ne $null)
     {
         if($ExchangeServerObj.ExchangeInformation.ExchangeVersion -ge [HealthChecker.ExchangeVersion]::Exchange2013)


### PR DESCRIPTION
First implementation of an Visual C++ Redistributable Package check to fulfill issue #134 .
It's a little bit complex to do this check nice and clear. I was not able to find a full version overview incl. version information for Visual C++ Redistributable 2012 and 2013. 
I've got the latest version from here: https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads.
We validate only if the latest known version of the required packaged (based on Exchange server role) is installed and if not, we show a red warning dialog with download resource to the latest version. We do this check for Exchange 2013 +

As this is the first implementation, there's space to improve this check.