### PR TITLE
Function Get-ExchangeServerMaintenanceState added

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .NOTES
 	Name: HealthChecker.ps1
 	Original Author: Marc Nivens


### PR DESCRIPTION
New function Get-ExchangeServerMaintenanceState added. This function is needed to check if the server is in maintenance mode or not (to address #181). We check for server maintenance as described here: https://docs.microsoft.com/en-us/exchange/high-availability/manage-ha/manage-dags?view=exchserver-2019
I'm still working on it (we have to do this check accurate to prevent false-positives). Another function will be introduced which brings the logic to evaluate the return of Get-ExchangeServerMaintenanceState and pass the object to "public object ServerComponentState".