### PR TITLE
Added ErrorAction Stop to Get-WmiObject for Win32_PowerPlan

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -1437,7 +1437,7 @@ param(
     $os = Get-WmiObject -ComputerName $Machine_Name -Class Win32_OperatingSystem
     try
     {
-        $plan = Get-WmiObject -ComputerName $Machine_Name -Class Win32_PowerPlan -Namespace root\cimv2\power -Filter "isActive='true'"
+        $plan = Get-WmiObject -ComputerName $Machine_Name -Class Win32_PowerPlan -Namespace root\cimv2\power -Filter "isActive='true'" -ErrorAction Stop
     }
     catch
     {


### PR DESCRIPTION
When we get an error here, we aren't getting tossed into the catch, so we need to set the ErrorAction for the command to be set to stop

Resolved #184