### PR TITLE
Fixed null-valued expression in Write-NICPacketReceivedDiscarded

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -3792,6 +3792,11 @@ param(
     )
         $cookedValue = 0
         $foundCounter = $false 
+        if($HealthExSvrObj.OSVersion.PacketsReceivedDiscarded -eq $null)
+        {
+            Write-VerboseOutput("HealthExSvrObj.OSVersion.PacketsReceivedDiscarded is null")
+            return
+        }
         foreach($instance in $HealthExSvrObj.OSVersion.PacketsReceivedDiscarded)
         {
             $instancePath = $instance.Path 


### PR DESCRIPTION
return out of the Write-NICPacketReceivedDiscarded function if the $HealthExSvrObj.OSVersion.PacketsReceivedDiscarded value is null

Resolved #183