### PR TITLE
Vulnerability check prepared for E19 CU3 E16 CU14

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -3473,6 +3473,13 @@ param(
 	            Test-VulnerabilitiesByBuildNumbersAndDisplay -ExchangeBuildRevision $buildRevision -SecurityFixedBuild 1779.4 -CVEName "CVE-2019-1137"
 	        }
 	    }
+	    if($exchangeCU -le [HealthChecker.ExchangeCULevel]::CU14)
+	    {
+	        if($exchangeCU -eq [HealthChecker.ExchangeCULevel]::CU14)
+	        {
+                Write-Green("There are no known vulnerabilities in this Exchange Server Version.")
+	        }
+	    }
     }
     elseif($HealthExSvrObj.ExchangeInformation.ExchangeVersion -eq [HealthChecker.ExchangeVersion]::Exchange2019)
     {
@@ -3519,6 +3526,13 @@ param(
 	            Test-VulnerabilitiesByBuildNumbersAndDisplay -ExchangeBuildRevision $buildRevision -SecurityFixedBuild 397.5 -CVEName "CVE-2019-1137"
 	        }
 	    }
+        if($exchangeCU -le [HealthChecker.ExchangeCULevel]::CU3)
+        {
+            if($exchangeCU -eq [HealthChecker.ExchangeCULevel]::CU3)
+            {
+                Write-Green("There are no known vulnerabilities in this Exchange Server Version.")
+            }
+        }
     }
     else 
     {


### PR DESCRIPTION
No known vulnerabilities for Exchange 2016 CU14 / Exchange 2019 CU3. Check is now ready to support these versions.