### PR TITLE
Partial fix to address issue #237

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -1191,6 +1191,22 @@ param(
     return $FileVersion_obj
 }
 
+Function Get-WindowsUpdateHistory {
+    try
+    {
+        $WindowsUpdateSession = New-Object -ComObject Microsoft.Update.Session
+        $WindowsUpdateSearcher = $WindowsUpdateSession.CreateUpdateSearcher()
+        $WindowsUpdateHistoryCount = $WindowsUpdateSearcher.GetTotalHistoryCount()
+        $WindowsUpdateResults = $WindowsUpdateSearcher.QueryHistory(0, $WindowsUpdateHistoryCount)
+        return $WindowsUpdateResults
+    }
+    catch
+    {
+        Write-VerboseOutput("Failed to get Windows Update History")
+        Invoke-CatchActions   
+    }
+}
+
 Function Get-HotFixListInfo{
 param(
 [Parameter(Mandatory=$true)][HealthChecker.OSVersionName]$OS_Version

--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -3737,6 +3737,25 @@ param(
                         }
                         if(-not($foundFixKB))
                         {
+                            Write-VerboseOutput("Fixing update not detected offline - going to query Windows Update Catalog for any replacing update")
+                            $ReplacingServerUpdates = Get-ReplacingServerUpdates -KBNumber $KBHashTable[$key] -Timeout 10 -ReturnReplacingKBNumbersOnly
+                            if($ReplacingServerUpdates -ne $null)
+                            {
+                                foreach($fixKB in $HotFixInfo)
+                                {
+                                    foreach($ReplacingUpdate in $ReplacingServerUpdates)
+                                    {
+                                        if($fixKB -eq $ReplacingUpdate)
+                                        {
+                                            Write-VerboseOutput("Found {0} that fixes the issue" -f $ReplacingUpdate)
+                                            $foundFixKB = $true 
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        if(-not($foundFixKB))
+                        {
                             Write-Break
                             Write-Break
                             Write-Red("July Update detected: Error --- Problem {0} detected without the fix {1}. This can cause odd issues to occur on the system. See https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/Issue-with-July-Updates-for-Windows-on-an-Exchange-Server/ba-p/608057" -f $key, ($KBHashTable[$key]))
@@ -3754,8 +3773,6 @@ param(
     {
         Write-VerboseOutput("No hotfixes were detected on the server")    
     }
-
-    
 }
 
 Function Display-KBHotfixCheck {

--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -1207,6 +1207,100 @@ Function Get-WindowsUpdateHistory {
     }
 }
 
+Function Get-ReplacingServerUpdates {
+param(
+[parameter(Mandatory=$true)][string]$KBNumber,
+[parameter(Mandatory=$true)][int]$Timeout,
+[parameter(Mandatory=$false)][switch]$ReturnReplacingKBNumbersOnly
+)
+    $ScriptBlock1 = {
+        Invoke-WebRequest -Uri "http://www.catalog.update.microsoft.com/Search.aspx?q=$($args[0])"
+    }
+    $ScriptBlock2 = {
+        Invoke-WebRequest -Uri "http://www.catalog.update.microsoft.com/ScopedViewGeneric.aspx?updateid=$($args[0])"
+    }
+
+    $WindowsCatalogCall1 = Start-Job -ScriptBlock $ScriptBlock1 -Name "WindowsCatalogCall1" -ArgumentList $KBNumber
+    do
+    {
+        $CatalogCall1Counter++
+        if((Get-Job -Id $WindowsCatalogCall1.Id).State -eq "Completed")
+        {
+            Write-VerboseOutput("WindowsCatalogCall1 after {0} attempts successfully completed. Receiving results..." -f $CatalogCall1Counter)
+            $WindowsCatalogKBInfo = Receive-Job -Id $WindowsCatalogCall1.Id -Keep
+            $WindowsCatalogUpdateId = $WindowsCatalogKBInfo.Links | Where-Object {$_.innerText -like "*Windows Server*x64*"}
+            Write-VerboseOutput("Removing background worker job: {0} with id: {1}" -f $WindowsCatalogCall1.Name,$WindowsCatalogCall1.Id)
+            Remove-Job -Id $WindowsCatalogCall1.Id
+            Break
+        }
+        else
+        {
+            Write-VerboseOutput("Attempt: {0} WebRequest not yet complete." -f $CatalogCall1Counter)
+            if($CatalogCall1Counter -eq 30)
+            {
+                Write-VerboseOutput("Removing background worker job: {0} with id: {1}" -f $WindowsCatalogCall1.Name,$WindowsCatalogCall1.Id)
+                Remove-Job -Id $WindowsCatalogCall1.Id
+                return $null
+                Break
+            }
+            Start-Sleep -Seconds 1
+        }
+    }
+    while($CatalogCall1Counter -lt $Timeout)
+
+    if($WindowsCatalogUpdateId.onclick -ne $null)
+    {
+        $WindowsCatalogCall2 = Start-Job -ScriptBlock $ScriptBlock2 -Name "WindowsCatalogCall2" -ArgumentList $($WindowsCatalogUpdateId.onclick.Split('"')[1])
+        do
+        {
+            $CatalogCall2Counter++
+            if((Get-Job -Id $WindowsCatalogCall2.Id).State -eq "Completed")
+            {
+                Write-VerboseOutput("WindowsCatalogCall2 after {0} attempts successfully completed. Receiving results..." -f $CatalogCall2Counter)
+                $WindowsCatalogDetailsInfo = Receive-Job -Id $WindowsCatalogCall2.Id -Keep
+                $WindowsCatalogReplaceUpdates = $WindowsCatalogDetailsInfo.Links | Where-Object {$_.href -like "*updateid=*"}
+                Write-VerboseOutput("Removing background worker job: {0} with id: {1}" -f $WindowsCatalogCall2.Name,$WindowsCatalogCall2.Id)
+                Remove-Job -Id $WindowsCatalogCall2.Id
+
+                if($ReturnReplacingKBNumbersOnly)
+                {
+                    $WindowsCatalogKBNumbersOnly = @()
+                    ForEach($Update in $WindowsCatalogReplaceUpdates)
+                    {
+                        $WindowsCatalogKBNumbersOnly += ($Update.outerText.split("(") -replace "[()]")[1]
+                    }
+                    return $WindowsCatalogKBNumbersOnly
+                    Break
+                }
+                else
+                {
+                    return $WindowsCatalogReplaceUpdates.outerText
+                    Break
+                }
+            }
+            else
+            {
+                Write-VerboseOutput("Attempt: {0} WebRequest not yet complete." -f $CatalogCall2Counter)
+                if($CatalogCall2Counter -eq 30)
+                {
+                    Write-VerboseOutput("Reached 30 attempts.")
+                    Write-VerboseOutput("Removing background worker job: {0} with id: {1}" -f $WindowsCatalogCall2.Name,$WindowsCatalogCall2.Id)
+                    Remove-Job -Id $WindowsCatalogCall2.Id
+                    return $null
+                    Break
+                }
+                Start-Sleep -Seconds 1
+            }
+        }
+        while($CatalogCall2Counter -lt $Timeout)
+    }
+    else
+    {
+        Write-VerboseOutput("We did not found any update which replaces: {0}" -f $KBNumber)
+        return $null
+    }
+}
+
 Function Get-HotFixListInfo{
 param(
 [Parameter(Mandatory=$true)][HealthChecker.OSVersionName]$OS_Version

--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -107,7 +107,7 @@ param(
 Note to self. "New Release Update" are functions that i need to update when a new release of Exchange is published
 #>
 
-$healthCheckerVersion = "2.36.0"
+$healthCheckerVersion = "2.36.1"
 $VirtualizationWarning = @"
 Virtual Machine detected.  Certain settings about the host hardware cannot be detected from the virtual machine.  Verify on the VM Host that: 
 


### PR DESCRIPTION
This fix work only if we're able to query the Windows Update Catalog. I've added two new functions:

- Get-WindowsUpdateHistory (not used yet but maybe interesting for future use)

- Get-ReplacingServerUpdates (used to do a live query against Windows Update Catalog to check for replacing updates in case the fixing update is not installed)

We should validate if the fix work accurate and decide if we keep it this way or address the issue on another way.