### PR TITLE
Write out debug log by default

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -521,9 +521,16 @@ function Write-VerboseOutput($message)
 
 function Write-DebugLog($message)
 {
-    if(![string]::IsNullOrWhiteSpace($message))
+    try
     {
-        $Script:Logger.WriteToFileOnly($message)
+        if(![string]::IsNullOrWhiteSpace($message))
+        {
+            $Script:Logger.WriteToFileOnly($message)
+        }
+    }
+    catch
+    {
+        # do nothing
     }
 }
 
@@ -832,7 +839,7 @@ if((Test-Path -Path "$env:ProgramData\ExchangeTools\HealthChecker") -ne $true)
     New-Item -ItemType Directory -Path "$env:ProgramData\ExchangeTools\HealthChecker" | Out-Null
 }
 
-$Script:Logger = New-LoggerObject -LogName "HealthChecker-Debug" -LogDirectory "$env:ProgramData\ExchangeTools\HealthChecker" -VerboseEnabled $true -EnableDateTime $false
+$Script:Logger = New-LoggerObject -LogName "HealthChecker-Debug" -LogDirectory "$env:ProgramData\ExchangeTools\HealthChecker" -VerboseEnabled $true -EnableDateTime $false -ErrorAction SilentlyContinue
 
 ############################################################
 ############################################################
@@ -6169,13 +6176,13 @@ Function Get-ErrorsThatOccurred {
         if(($Error.Count - $Script:ErrorStartCount) -ne $Script:ErrorsExcludedCount)
         {
             Write-Red("There appears to have been some errors in the script. To assist with debugging of the script, please RE-RUN the script with -Verbose send the .txt and .xml file to ExToolsFeedback@microsoft.com.")
-	        $Script:Logger.PreventLogCleanup = $true
+	        try{$Script:Logger.PreventLogCleanup = $true}catch{}
             Write-Errors
         }
         elseif($Script:VerboseEnabled)
         {
             Write-VerboseOutput("All errors that occurred were in try catch blocks and was handled correctly.")
-	        $Script:Logger.PreventLogCleanup = $true
+	        try{$Script:Logger.PreventLogCleanup = $true}catch{}
             Write-Errors
         }
     }
@@ -6296,5 +6303,5 @@ finally
     {
         $Host.PrivateData.VerboseForegroundColor = $VerboseForeground
     }
-    $Script:Logger.RemoveLatestLogFile()
+    try{$Script:Logger.RemoveLatestLogFile()}catch{}
 }

--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -521,16 +521,9 @@ function Write-VerboseOutput($message)
 
 function Write-DebugLog($message)
 {
-    try
+    if(![string]::IsNullOrEmpty($message))
     {
-        if(![string]::IsNullOrWhiteSpace($message))
-        {
-            $Script:Logger.WriteToFileOnly($message)
-        }
-    }
-    catch
-    {
-        # do nothing
+        $Script:Logger.WriteToFileOnly($message)
     }
 }
 
@@ -661,7 +654,7 @@ param(
     {
         $LogDirectory = (Get-Location).Path
     }
-    if([string]::IsNullOrWhiteSpace($LogName))
+    if([string]::IsNullOrEmpty($LogName))
     {
         throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LogName" 
     }
@@ -701,7 +694,7 @@ param(
         param(
         [string]$LoggingString
         )
-        if([string]::IsNullOrWhiteSpace($LoggingString))
+        if([string]::IsNullOrEmpty($LoggingString))
         {
             throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LoggingString"
         }
@@ -720,7 +713,7 @@ param(
         param(
         [string]$LoggingString
         )
-        if([string]::IsNullOrWhiteSpace($LoggingString))
+        if([string]::IsNullOrEmpty($LoggingString))
         {
             throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LoggingString"
         }
@@ -739,7 +732,7 @@ param(
         param(
         [string]$LoggingString
         )
-        if([string]::IsNullOrWhiteSpace($LoggingString))
+        if([string]::IsNullOrEmpty($LoggingString))
         {
             throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LoggingString"
         }
@@ -824,7 +817,7 @@ param(
     $loggerObject.UpdateFileLocation()
     try 
     {
-        "[{0}] : Creating a new logger instance" -f [System.DAteTime]::Now | Out-File ($loggerObject.FullPath) -Append
+        "[{0}] : Creating a new logger instance" -f [System.DateTime]::Now | Out-File ($loggerObject.FullPath) -Append
     }
     catch 
     {
@@ -6161,6 +6154,7 @@ Function Get-ErrorsThatOccurred {
                 }
                 if(!($goodError))
                 {
+                    Write-DebugLog $Error[$index]
                     $Error[$index] | Out-File ($Script:OutputFullPath) -Append
                 }
                 $index++
@@ -6176,13 +6170,13 @@ Function Get-ErrorsThatOccurred {
         if(($Error.Count - $Script:ErrorStartCount) -ne $Script:ErrorsExcludedCount)
         {
             Write-Red("There appears to have been some errors in the script. To assist with debugging of the script, please RE-RUN the script with -Verbose send the .txt and .xml file to ExToolsFeedback@microsoft.com.")
-	        try{$Script:Logger.PreventLogCleanup = $true}catch{}
+	        $Script:Logger.PreventLogCleanup = $true
             Write-Errors
         }
         elseif($Script:VerboseEnabled)
         {
             Write-VerboseOutput("All errors that occurred were in try catch blocks and was handled correctly.")
-	        try{$Script:Logger.PreventLogCleanup = $true}catch{}
+	        $Script:Logger.PreventLogCleanup = $true
             Write-Errors
         }
     }
@@ -6303,5 +6297,5 @@ finally
     {
         $Host.PrivateData.VerboseForegroundColor = $VerboseForeground
     }
-    try{$Script:Logger.RemoveLatestLogFile()}catch{}
+    $Script:Logger.RemoveLatestLogFile()
 }

--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -553,6 +553,267 @@ param(
 
 $Script:VerboseFunctionCaller = ${Function:Write-VerboseOutput}
 
+#Function Version 1.0
+Function Write-ScriptMethodHostWriter{
+param(
+[Parameter(Mandatory=$true)][string]$WriteString
+)
+    if($this.LoggerObject -ne $null)
+    {
+        $this.LoggerObject.WriteHost($WriteString) 
+    }
+    elseif($this.HostFunctionCaller -eq $null)
+    {
+        Write-Host $WriteString
+    }
+    else 
+    {
+        $this.HostFunctionCaller($WriteString)
+    }
+}
+
+#Function Version 1.0
+Function Write-ScriptMethodVerboseWriter {
+param(
+[Parameter(Mandatory=$true)][string]$WriteString
+)
+    if($this.LoggerObject -ne $null)
+    {
+        $this.LoggerObject.WriteVerbose($WriteString)
+    }
+    elseif($this.VerboseFunctionCaller -eq $null -and 
+        $this.WriteVerboseData)
+    {
+        Write-Host $WriteString -ForegroundColor Cyan 
+    }
+    elseif($this.WriteVerboseData)
+    {
+        $this.VerboseFunctionCaller($WriteString)
+    }
+}
+
+Function New-LoggerObject {
+[CmdletBinding()]
+param(
+[Parameter(Mandatory=$false)][string]$LogDirectory = ".",
+[Parameter(Mandatory=$false)][string]$LogName = "Script_Logging",
+[Parameter(Mandatory=$false)][bool]$EnableDateTime = $true,
+[Parameter(Mandatory=$false)][bool]$IncludeDateTimeToFileName = $true,
+[Parameter(Mandatory=$false)][int]$MaxFileSizeInMB = 10,
+[Parameter(Mandatory=$false)][int]$CheckSizeIntervalMinutes = 10,
+[Parameter(Mandatory=$false)][int]$NumberOfLogsToKeep = 10,
+[Parameter(Mandatory=$false)][bool]$VerboseEnabled,
+[Parameter(Mandatory=$false)][scriptblock]$HostFunctionCaller,
+[Parameter(Mandatory=$false)][scriptblock]$VerboseFunctionCaller
+)
+
+    #Function Version 1.1
+    <# 
+    Required Functions: 
+        https://raw.githubusercontent.com/dpaulson45/PublicPowerShellScripts/master/Functions/Write-HostWriters/Write-ScriptMethodHostWriter.ps1
+        https://raw.githubusercontent.com/dpaulson45/PublicPowerShellScripts/master/Functions/Write-VerboseWriters/Write-ScriptMethodVerboseWriter.ps1
+    #>
+
+    ########################
+    #
+    # Template Functions
+    #
+    ########################
+
+    Function Write-ToLog {
+    param(
+    [string]$WriteString,
+    [string]$LogLocation
+    )
+        $WriteString | Out-File ($LogLocation) -Append
+    }
+
+    ########################
+    #
+    # End Template Functions
+    #
+    ########################
+
+
+    ########## Parameter Binding Exceptions ##############
+    # throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid ParameterName" 
+    if($LogDirectory -eq ".")
+    {
+        $LogDirectory = (Get-Location).Path
+    }
+    if([string]::IsNullOrWhiteSpace($LogName))
+    {
+        throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LogName" 
+    }
+    if(!(Test-Path $LogDirectory))
+    {
+        throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LogDirectory" 
+    }
+
+    $loggerObject = New-Object pscustomobject 
+    $loggerObject | Add-Member -MemberType NoteProperty -Name "FileDirectory" -Value $LogDirectory
+    $loggerObject | Add-Member -MemberType NoteProperty -Name "FileName" -Value $LogName
+    $loggerObject | Add-Member -MemberType NoteProperty -Name "FullPath" -Value $fullLogPath
+    $loggerObject | Add-Member -MemberType NoteProperty -Name "InstanceBaseName" -Value ([string]::Empty)
+    $loggerObject | Add-Member -MemberType NoteProperty -Name "EnableDateTime" -Value $EnableDateTime
+    $loggerObject | Add-Member -MemberType NoteProperty -Name "IncludeDateTimeToFileName" -Value $IncludeDateTimeToFileName
+    $loggerObject | Add-Member -MemberType NoteProperty -Name "MaxFileSizeInMB" -Value $MaxFileSizeInMB
+    $loggerObject | Add-Member -MemberType NoteProperty -Name "CheckSizeIntervalMinutes" -Value $CheckSizeIntervalMinutes
+    $loggerObject | Add-Member -MemberType NoteProperty -Name "NextFileCheckTime" -Value ((Get-Date).AddMinutes($CheckSizeIntervalMinutes))
+    $loggerObject | Add-Member -MemberType NoteProperty -Name "InstanceNumber" -Value 1
+    $loggerObject | Add-Member -MemberType NoteProperty -Name "NumberOfLogsToKeep" -Value $NumberOfLogsToKeep
+    $loggerObject | Add-Member -MemberType NoteProperty -Name "WriteVerboseData" -Value $VerboseEnabled
+    $loggerObject | Add-Member -MemberType NoteProperty -Name "PreventLogCleanup" -Value $false
+    $loggerObject | Add-Member -MemberType ScriptMethod -Name "ToLog" -Value ${Function:Write-ToLog}
+    $loggerObject | Add-Member -MemberType ScriptMethod -Name "WriteHostWriter" -Value ${Function:Write-ScriptMethodHostWriter}
+    $loggerObject | Add-Member -MemberType ScriptMethod -Name "WriteVerboseWriter" -Value ${Function:Write-ScriptMethodVerboseWriter}
+
+    if($HostFunctionCaller -ne $null)
+    {
+        $loggerObject | Add-Member -MemberType ScriptMethod -Name "HostFunctionCaller" -Value $HostFunctionCaller
+    }
+    if($VerboseFunctionCaller -ne $null)
+    {
+        $loggerObject | Add-Member -MemberType ScriptMethod -Name "VerboseFunctionCaller" -Value $VerboseFunctionCaller
+    }
+
+    $loggerObject | Add-Member -MemberType ScriptMethod -Name "WriteHost" -Value {
+        param(
+        [string]$LoggingString
+        )
+        if([string]::IsNullOrWhiteSpace($LoggingString))
+        {
+            throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LoggingString"
+        }
+
+        if($this.EnableDateTime)
+        {
+            $LoggingString = "[{0}] : {1}" -f [System.DateTime]::Now, $LoggingString
+        }
+
+        $this.WriteHostWriter($LoggingString)
+        $this.ToLog($LoggingString, $this.FullPath)
+        $this.LogUpKeep()
+    }
+
+    $loggerObject | Add-Member -MemberType ScriptMethod -Name "WriteVerbose" -Value {
+        param(
+        [string]$LoggingString
+        )
+        if([string]::IsNullOrWhiteSpace($LoggingString))
+        {
+            throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LoggingString"
+        }
+
+        if($this.EnableDateTime)
+        {
+            $LoggingString = "[{0}] : {1}" -f [System.DateTime]::Now, $LoggingString
+        }
+        $this.WriteVerboseWriter($LoggingString)
+        $this.ToLog($LoggingString, $this.FullPath)
+        $this.LogUpKeep() 
+
+    }
+
+    $loggerObject | Add-Member -MemberType ScriptMethod -Name "WriteToFileOnly" -Value {
+        param(
+        [string]$LoggingString
+        )
+        if([string]::IsNullOrWhiteSpace($LoggingString))
+        {
+            throw [System.Management.Automation.ParameterBindingException] "Failed to provide valid LoggingString"
+        }
+
+        if($this.EnableDateTime)
+        {
+            $LoggingString = "[{0}] : {1}" -f [System.DateTime]::Now, $LoggingString
+        }
+        $this.ToLog($LoggingString, $this.FullPath)
+        $this.LogUpKeep()
+    }
+
+    $loggerObject | Add-Member -MemberType ScriptMethod -Name "UpdateFileLocation" -Value{
+
+        if($this.FullPath -eq $null)
+        {
+            if($this.IncludeDateTimeToFileName)
+            {
+                $this.InstanceBaseName = "{0}_{1}" -f $this.FileName, ((Get-Date).ToString('yyyyMMddHHmmss'))
+                $this.FullPath = "{0}\{1}.txt" -f $this.FileDirectory, $this.InstanceBaseName
+            }
+            else 
+            {
+                $this.InstanceBaseName = "{0}" -f $this.FileName
+                $this.FullPath = "{0}\{1}.txt" -f $this.FileDirectory, $this.InstanceBaseName
+            }
+        }
+        else 
+        {
+
+            do{
+                $this.FullPath = "{0}\{1}_{2}.txt" -f $this.FileDirectory, $this.InstanceBaseName, $this.InstanceNumber
+                $this.InstanceNumber++
+            }while(Test-Path $this.FullPath)
+            $this.WriteVerbose("Updated to New Log")
+        }
+    }
+
+    $loggerObject | Add-Member -MemberType ScriptMethod -Name "LogUpKeep" -Value {
+
+        if($this.NextFileCheckTime -gt [System.DateTime]::Now)
+        {
+            return 
+        }
+        $this.NextFileCheckTime = (Get-Date).AddMinutes($this.CheckSizeIntervalMinutes)
+        $this.CheckFileSize()
+        $this.CheckNumberOfFiles()
+        $this.WriteVerbose("Did Log Object Up Keep")
+    }
+
+    $loggerObject | Add-Member -MemberType ScriptMethod -Name "CheckFileSize" -Value {
+
+        $item = Get-ChildItem $this.FullPath
+        if(($item.Length / 1MB) -gt $this.MaxFileSizeInMB)
+        {
+            $this.UpdateFileLocation()
+        }
+    }
+
+    $loggerObject | Add-Member -MemberType ScriptMethod -Name "CheckNumberOfFiles" -Value {
+
+        $filter = "{0}*" -f $this.InstanceBaseName
+        $items = Get-ChildItem -Path $this.FileDirectory | ?{$_.Name -like $filter}
+        if($items.Count -gt $this.NumberOfLogsToKeep)
+        {
+            do{
+                $items | Sort-Object LastWriteTime | Select -First 1 | Remove-Item -Force 
+                $items = Get-ChildItem -Path $this.FileDirectory | ?{$_.Name -like $filter}
+            }while($items.Count -gt $this.NumberOfLogsToKeep)
+        }
+    }
+
+    $loggerObject | Add-Member -MemberType ScriptMethod -Name "RemoveLatestLogFile" -Value {
+
+        if(!$this.PreventLogCleanup)
+        {
+            $item = Get-ChildItem $this.FullPath
+            Remove-Item $item -Force
+        }
+    }
+
+    $loggerObject.UpdateFileLocation()
+    try 
+    {
+        "[{0}] : Creating a new logger instance" -f [System.DAteTime]::Now | Out-File ($loggerObject.FullPath) -Append
+    }
+    catch 
+    {
+        throw 
+    }
+
+    return $loggerObject
+}
+
 ############################################################
 ############################################################
 

--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -514,6 +514,14 @@ function Write-VerboseOutput($message)
     }
 }
 
+function Write-DebugLog($message)
+{
+    if(![string]::IsNullOrWhiteSpace($message))
+    {
+        $Script:Logger.WriteToFileOnly($message)
+    }
+}
+
 Function Write-Break {
     Write-Host ""
 }


### PR DESCRIPTION
We write out a debug log by default. We automatically delete the debug log if no script error occurs. You can find the debug log here: %programdata%\ExchangeTools\HealthChecker 