### PR TITLE
Initial quick fix for issue #252 doesn't work on WMF 2

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -876,7 +876,8 @@ param(
     Write-VerboseOutput("Passed: $OS_Version")
     
     #Quick fix to address issue 252
-    if($OS_Version -gt 10.0.14393)
+    [int]$intOSVersion = $OS_Version.Replace(".","")
+    if($intOSVersion -gt 10014393)
     {
         $OS_Version = "10.0.17713"
     }


### PR DESCRIPTION
Error: Unexpected token '.14393' in expression or statement.
Fixed by replacing the . and converting the result to int. After that we can compare it with the Server 2019 int build number.
Works on 2008 R2 with WMF 2.
