### PR TITLE
Get-ReplacingServerUpdates improvements

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -1649,10 +1649,10 @@ param(
 [parameter(Mandatory=$false)][switch]$ReturnReplacingKBNumbersOnly
 )
     $ScriptBlock1 = {
-        Invoke-WebRequest -Uri "http://www.catalog.update.microsoft.com/Search.aspx?q=$($args[0])" -UseBasicParsing
+        Invoke-WebRequest -Uri "https://www.catalog.update.microsoft.com/Search.aspx?q=$($args[0])" -UseBasicParsing
     }
     $ScriptBlock2 = {
-        Invoke-WebRequest -Uri "http://www.catalog.update.microsoft.com/ScopedViewGeneric.aspx?updateid=$($args[0])" -UseBasicParsing
+        Invoke-WebRequest -Uri "https://www.catalog.update.microsoft.com/ScopedViewGeneric.aspx?updateid=$($args[0])" -UseBasicParsing
     }
 
     $WindowsCatalogCall1 = Start-Job -ScriptBlock $ScriptBlock1 -Name "WindowsCatalogCall1" -ArgumentList $KBNumber
@@ -1663,7 +1663,7 @@ param(
         {
             Write-VerboseOutput("WindowsCatalogCall1 after {0} attempts successfully completed. Receiving results..." -f $CatalogCall1Counter)
             $WindowsCatalogKBInfo = Receive-Job -Id $WindowsCatalogCall1.Id -Keep
-            $WindowsCatalogUpdateId = $WindowsCatalogKBInfo.Links | Where-Object {$_.innerText -like "*Windows Server*x64*"}
+            $WindowsCatalogUpdateId = $WindowsCatalogKBInfo.Links | Where-Object {$_.outerHTML -like "*Windows Server*x64*"}
             Write-VerboseOutput("Removing background worker job: {0} with id: {1}" -f $WindowsCatalogCall1.Name,$WindowsCatalogCall1.Id)
             Remove-Job -Id $WindowsCatalogCall1.Id
             Break
@@ -1671,10 +1671,12 @@ param(
         else
         {
             Write-VerboseOutput("Attempt: {0} WebRequest not yet complete." -f $CatalogCall1Counter)
-            if($CatalogCall1Counter -eq 30)
+            if($CatalogCall1Counter -eq $Timeout)
             {
+	    	Write-VerboseOutput("Reached {0} attempts." -f $Timeout)
                 Write-VerboseOutput("Removing background worker job: {0} with id: {1}" -f $WindowsCatalogCall1.Name,$WindowsCatalogCall1.Id)
-                Remove-Job -Id $WindowsCatalogCall1.Id
+                Stop-Job -Id $WindowsCatalogCall1.Id
+		Remove-Job -Id $WindowsCatalogCall1.Id
                 return $null
                 Break
             }
@@ -1702,7 +1704,7 @@ param(
                     $WindowsCatalogKBNumbersOnly = @()
                     ForEach($Update in $WindowsCatalogReplaceUpdates)
                     {
-                        $WindowsCatalogKBNumbersOnly += ($Update.outerText.split("(") -replace "[()]")[1]
+                        $WindowsCatalogKBNumbersOnly += (($Update.outerHTML.split("(") -replace "[()]") -replace "[</a>]")[1]
                     }
                     return $WindowsCatalogKBNumbersOnly
                     Break
@@ -1716,11 +1718,12 @@ param(
             else
             {
                 Write-VerboseOutput("Attempt: {0} WebRequest not yet complete." -f $CatalogCall2Counter)
-                if($CatalogCall2Counter -eq 30)
+                if($CatalogCall2Counter -eq $Timeout)
                 {
-                    Write-VerboseOutput("Reached 30 attempts.")
+                    Write-VerboseOutput("Reached {0} attempts." -f $Timeout)
                     Write-VerboseOutput("Removing background worker job: {0} with id: {1}" -f $WindowsCatalogCall2.Name,$WindowsCatalogCall2.Id)
-                    Remove-Job -Id $WindowsCatalogCall2.Id
+                    Stop-Job -Id $WindowsCatalogCall2.Id
+		    Remove-Job -Id $WindowsCatalogCall2.Id
                     return $null
                     Break
                 }


### PR DESCRIPTION
To address issue #250 . We've included -UseBasicParsing which is default with PowerShell 6. This change requires to update the parsing logic to make sure to get the right Microsoft Update Catalog guid.
Changed also Update Catalog url from http to https and added Stop-Job before Remove-Job if we reach the specified Timeout value.