### PR TITLE
Improvement of Confirm-ExchangeShell method

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -1037,9 +1037,24 @@ if((Test-Path 'HKLM:\SOFTWARE\Microsoft\ExchangeServer\v14\Setup') -or
 
     try
     {
+        if(((Get-PSSession | Where-Object {($_.Availability -eq 'Available') -and ($_.ConfigurationName -eq 'Microsoft.Exchange')}).Count -eq 0) -and
+        ((Get-Module -Name RemoteExchange).Count -eq 1))
+        {
+            Write-VerboseWriter("Removing RemoteExchange module")
+            Remove-Module -Name RemoteExchange
+            $CurrentPSModules = Get-Module
+            ForEach($PSModule in $CurrentPSModules)
+            {
+                if(($PSModule.ModuleType -eq "Script") -and ($PSModule.ModuleBase -like "*\Microsoft\Exchange\RemotePowerShell\*"))
+                {
+                    Write-VerboseWriter("Removing module {0} for implicit remoting" -f $PSModule.Name)
+                    Remove-Module -Name $PSModule.Name
+                }
+            }
+        }
         Get-ExchangeServer -ErrorAction Stop | Out-Null
         Write-VerboseWriter("Exchange PowerShell Module already loaded.")
-        $passed = $true 
+        $passed = $true
     }
     catch 
     {


### PR DESCRIPTION
To address issue #300 
When Exchange Management Shell is executed
```
C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -noexit -command ". 'C:\Program Files\Microsoft\Exchange Server\V15\bin\RemoteExchange.ps1'; Connect-ExchangeServer -auto -ClientApplication:ManagementShell "
```
we create the implicit remoting module (if it doesn't exist). 

We do this by running the Export-PSSession cmdlet. Output is stored here: `C:\Users\Username\AppData\Roaming\Microsoft\Exchange\RemotePowerShell\Computername`
where username is the user in which context the Exchange Management Shell was executed and computername is the remote computer to which the session was established. 

We do the same in HealthChecker script:
```
Import-Module $env:ExchangeInstallPath\bin\RemoteExchange.ps1 -ErrorAction Stop
Connect-ExchangeServer -Auto -ClientApplication:ManagementShell
```
If the PSSession is no longer available or removed, we're still able to call the Exchange cmdlets because we have them available due to implicit remoting module (Get-Module should show something like this):
```
[PS] C:\Windows\system32>Get-Module

ModuleType Version    Name                                ExportedCommands
---------- -------    ----                                ----------------
Script     1.0        2012r2-ex2016.contoso.dom           {Add-ADPermission, Add-AvailabilityAddressSpace, Add-Conte...
```
In this case, we make use of the Get-ExchangeServer module which is available due to the implicit remoting module. If Get-ExchangeServer is executed, we're trying at first to re-establish the PSSession using the InstanceId which was valid at the time when Export-PSSession cmdlet was called. This is part of the Get-PSImplicitRemotingSession method which is a method within the implicit remoting module. This fails (we suppress the error output, but the error is still added to $error). We finally establish a new session for implicit remoting - that's the reason why script executed successful. 

I improved the Confirm-ExchangeShell method as described below:
We check if Get-PSSession returns ***no*** sessions with ConfigurationName Microsoft.Exchange which are available but RemoteExchange script module loaded.
If this is the case we're going to unload the RemoteExchange script as well as the implicit remoting module. Result of this is: Get-ExchangeServer -ErrorAction Stop | Out-Null fails and so we're going to reload the RemoteExchange module as well as executing Connect-ExchangeServer to establish a clean session.