### PR TITLE
Test-VulnerabilitiesByBuildNumbersAndDisplay method rewritten

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -3947,7 +3947,7 @@ param(
     $RegValue = Invoke-RegistryHandler -RegistryHive "LocalMachine" -MachineName $Machine_Name -SubKey "SYSTEM\CurrentControlSet\Control\Lsa" -GetValue "DisableLoopbackCheck"
     If ($RegValue)
     {
-        Write-Red("System vulnerable to CVE-2018-8581.  See: https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-8581 for more information.")  
+        Write-Red("System vulnerable to CVE-2018-8581.`r`n`tSee: https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2018-8581 for more information.")  
         $Script:AllVulnerabilitiesPassed = $false 
     }
     Else
@@ -3977,8 +3977,7 @@ param(
                 {
                     If ((([DateTime]::ParseExact($KB2565063_RegValueInstallDate,”yyyyMMdd”,$null))) -lt (([DateTime]::ParseExact($E15_RegValueInstallData,”yyyyMMdd”,$null))))
                     {
-                        Write-Red("Vulnerable to CVE-2010-3190.")
-                        Write-Red("See: https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/MS11-025-required-on-Exchange-Server-versions-released-before/ba-p/608353 for more information.")
+                        Write-Red("Vulnerable to CVE-2010-3190.`r`n`tSee: https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/MS11-025-required-on-Exchange-Server-versions-released-before/ba-p/608353 for more information.")
                     }
                     Else
                     {
@@ -3988,14 +3987,12 @@ param(
                 Else
                 {
                     Write-Yellow("Unable to determine Exchange server install date!")
-                    Write-Yellow("Potentially vulnerable to CVE-2010-3190.")
-                    Write-Yellow("See: https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/MS11-025-required-on-Exchange-Server-versions-released-before/ba-p/608353 for more information.")
+                    Write-Yellow("Potentially vulnerable to CVE-2010-3190.`r`n`tSee: https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/MS11-025-required-on-Exchange-Server-versions-released-before/ba-p/608353 for more information.")
                 }
             }
             Else
             {
-                Write-Red("Vulnerable to CVE-2010-3190.")
-                Write-Red("See: https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/MS11-025-required-on-Exchange-Server-versions-released-before/ba-p/608353 for more information.")
+                Write-Red("Vulnerable to CVE-2010-3190.`r`n`tSee: https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/MS11-025-required-on-Exchange-Server-versions-released-before/ba-p/608353 for more information.")
             }
         }
         Else
@@ -4016,8 +4013,7 @@ param(
             {
                 If ((([DateTime]::ParseExact($KB2565063_RegValueInstallDate,”yyyyMMdd”,$null))) -lt (([DateTime]::ParseExact($E2010_RegValueInstallDate,”yyyyMMdd”,$null))))
                 {
-                    Write-Red("Potentially Vulnerable to CVE-2010-3190.")
-                    Write-Red("See: https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/MS11-025-required-on-Exchange-Server-versions-released-before/ba-p/608353 for more information.")
+                    Write-Red("Potentially Vulnerable to CVE-2010-3190.`r`n`tSee: https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/MS11-025-required-on-Exchange-Server-versions-released-before/ba-p/608353 for more information.")
                 }
                 Else
                 {


### PR DESCRIPTION
Test-VulnerabilitiesByBuildNumbersAndDisplay method rewritten to address issue #302 and issue #306 . Moving away from using double which cause problems if private part is 10, 20, 30... . 
We now pass ExchangeBuildRevision as string to the method, split them into BuildPart and PrivatePart as integer and pass them into a switch statement. This is more complex than comparing double values but it's worth it to reduce false/positives and false/negatives.