### PR TITLE
Vulnerability Check for CVE-2020-1147 added

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -4024,6 +4024,7 @@ param(
                     If ((([DateTime]::ParseExact($KB2565063_RegValueInstallDate,”yyyyMMdd”,$null))) -lt (([DateTime]::ParseExact($E15_RegValueInstallData,”yyyyMMdd”,$null))))
                     {
                         Write-Red("Vulnerable to CVE-2010-3190.`r`n`tSee: https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/MS11-025-required-on-Exchange-Server-versions-released-before/ba-p/608353 for more information.")
+                        $Script:AllVulnerabilitiesPassed = $false
                     }
                     Else
                     {
@@ -4039,6 +4040,7 @@ param(
             Else
             {
                 Write-Red("Vulnerable to CVE-2010-3190.`r`n`tSee: https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/MS11-025-required-on-Exchange-Server-versions-released-before/ba-p/608353 for more information.")
+                $Script:AllVulnerabilitiesPassed = $false
             }
         }
         Else
@@ -4060,6 +4062,7 @@ param(
                 If ((([DateTime]::ParseExact($KB2565063_RegValueInstallDate,”yyyyMMdd”,$null))) -lt (([DateTime]::ParseExact($E2010_RegValueInstallDate,”yyyyMMdd”,$null))))
                 {
                     Write-Red("Potentially Vulnerable to CVE-2010-3190.`r`n`tSee: https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/MS11-025-required-on-Exchange-Server-versions-released-before/ba-p/608353 for more information.")
+                    $Script:AllVulnerabilitiesPassed = $false
                 }
                 Else
                 {
@@ -4070,6 +4073,7 @@ param(
             {
                 Write-Red("Unable to determine Exchange server install date!")
                 Write-Red("Potentially vulnerable to CVE-2010-3190.")
+                $Script:AllVulnerabilitiesPassed = $false
             }
         }
         Else
@@ -4077,6 +4081,7 @@ param(
             Write-Red("`nPotentially vulnerable to CVE-2010-3190.")
             Write-Red("You should check if your build is prior October 2018 and if so, install KB2565063")
             Write-Red("See: https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/MS11-025-required-on-Exchange-Server-versions-released-before/ba-p/608353 for more information.")
+            $Script:AllVulnerabilitiesPassed = $false
         }
     }
 

--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -4106,6 +4106,7 @@ param(
                 {
                     Write-VerboseOutput("Workaround to disable affected SMBv3 compression is NOT in place.")
                     Write-Red("System vulnerable to CVE-2020-0796.`r`n`tSee: https://portal.msrc.microsoft.com/en-us/security-guidance/advisory/CVE-2020-0796 for more information.")
+                    $Script:AllVulnerabilitiesPassed = $false
                 }
             }
             else 

--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -4132,7 +4132,7 @@ param(
 
     Write-VerboseOutput("Testing CVE: CVE-2020-1147")
     $netInstallPath = Invoke-RegistryHandler -RegistryHive "LocalMachine" -MachineName $Machine_Name -SubKey "SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full" -GetValue "InstallPath"
-    if($netInstallPath)
+    if($netInstallPath -and ($HealthExSvrObj.NetVersionInfo.NetVersion -ne [HealthChecker.NetVersion]::Unknown))
     {
         if($Machine_Name -match $env:COMPUTERNAME)
         {
@@ -4183,8 +4183,9 @@ param(
     }
     else 
     {
-        Write-Red("Unable to determine .NET Framework install path!")
+        Write-Red("Unable to determine .NET Framework install path or .NET Framework version!")
         Write-Red("Potentially vulnerable to CVE-2020-1147.")
+        $Script:AllVulnerabilitiesPassed = $false
     }
 
     #Check for different vulnerabilities


### PR DESCRIPTION
First check implementation to validate if the system is vulnerable to CVE-2020-1147 (https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-1147)