### PR TITLE
New Function: Test-RequiresServerFqdn

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -6721,7 +6721,8 @@ Function LoadBalancingMain {
 }
 Function HealthCheckerMain {
 
-    Set-ScriptLogFileLocation -FileName "HealthCheck" -IncludeServerName $true 
+    Set-ScriptLogFileLocation -FileName "HealthCheck" -IncludeServerName $true
+    Test-RequiresServerFqdn -ServerName $Server 
     Write-HealthCheckerVersion
     $HealthObject = Build-HealthExchangeServerObject $Server
     Display-ResultsToScreen $healthObject

--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -980,6 +980,25 @@ param(
     return $isCurrent
 }
 
+Function Test-RequiresServerFqdn {
+param(
+[Parameter(Mandatory=$true)][string]$ServerName
+)
+    Write-VerboseOutput("Calling: Test-RequiresServerFqdn")
+    try 
+    {
+        $temp_remotedate = Invoke-Command -ComputerName $ServerName -ScriptBlock {Get-Date} -ErrorAction Stop
+        Write-VerboseOutput("Connected successfully using NetBIOS name.")
+    }
+    catch
+    {
+        Invoke-CatchActions
+        Write-VerboseOutput("Failed to connect to {0} using NetBIOS name. Fallback to Fqdn" -f $ServerName)
+        $Script:Server = (Get-ExchangeServer $ServerName).FQDN
+        Write-VerboseOutput("ServerName set to {0}" -f $Script:Server)
+    }
+}
+
 Function Invoke-RegistryHandler {
 param(
 [Parameter(Mandatory=$false)][string]$RegistryHive = "LocalMachine",


### PR DESCRIPTION
Added a new function to validate if we can connect to a remote server using invoke-command via NetBIOS name. We fallback to Fqdn if it's not possible to establish the connection by using the NetBIOS name.