### PR TITLE
Fixed .NET Framework to use Friendly Name in warning message

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -3686,7 +3686,8 @@ param(
         $testObject = New-Object PSCustomObject
         $testObject | Add-Member -MemberType NoteProperty -Name "CurrentValue" -Value ($osInformation.NETFramework.FriendlyName)
         $testObject | Add-Member -MemberType NoteProperty -Name "MaxSupportedVersion" -Value ($exchangeInformation.NETFramework.MaxSupportedVersion)
-        $displayValue = "{0} - Warning Recommended .NET Version is {1}" -f $osInformation.NETFramework.FriendlyName, $exchangeInformation.NETFramework.MaxSupportedVersion
+        $displayFriendly = Get-NETFrameworkVersion -NetVersionKey $exchangeInformation.NETFramework.MaxSupportedVersion
+        $displayValue = "{0} - Warning Recommended .NET Version is {1}" -f $osInformation.NETFramework.FriendlyName, $displayFriendly.FriendlyName
         $analyzedResults = Add-AnalyzedResultInformation -Name ".NET Framework" -Details $displayValue `
             -DisplayGroupingKey $keyOSInformation `
             -DisplayWriteType "Yellow" `


### PR DESCRIPTION
If we are not on the recommended version for .NET and Exchange, we now display the Friendly Name vs the enum name.

Resolves #333