### PR TITLE
Out of date CU DisplayWriteType set to Red

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -3522,6 +3522,7 @@ param(
 
         $analyzedResults = Add-AnalyzedResultInformation -Name "Error" -Details ("Out of date Cumulative Update. Please upgrade to one of the two most recently released Cumulative Updates. Currently running on a build that is {0} days old." -f $daysOld) `
             -DisplayGroupingKey $keyExchangeInformation `
+            -DisplayWriteType "Red" `
             -DisplayCustomTabNumber 2 `
             -AddHtmlDetailRow $false `
             -AnalyzedInformation $analyzedResults


### PR DESCRIPTION
Out of date CU message was displayed as informational (grey). Set it to Red.