### PR TITLE
Get-DotNetDllFileVersions adjustments to make CVE-2020-1147 working on v3

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -1498,15 +1498,16 @@ Function Get-DotNetDllFileVersions {
         }
         else
         {
+            $preCookedNetDllVersionInfo = (($getItem.VersionInfo.Split("`n") | Select-String 'ProductVersion') -Split(":")).Trim()[1]
+
             $cookedNetDllFileInfo = New-Object PSCustomObject
             $cookedNetDllFileInfo | Add-Member -MemberType NoteProperty -Name "LastWriteTimeUtc" -Value ([datetime]($getItem.LastWriteTimeUtc))
             $cookedNetDllFileInfo | Add-Member -MemberType NoteProperty -Name "VersionInfo" -Value ([PSCustomObject]@{
-                FileMajorPart = ([int](($getItem.VersionInfo.Split("`n") | Select-String 'ProductVersion') -Split(":")).Trim()[1].Split(".")[0])
-                FileMinorPart = ([int](($getItem.VersionInfo.Split("`n") | Select-String 'ProductVersion') -Split(":")).Trim()[1].Split(".")[1])
-                FileBuildPart = ([int](($getItem.VersionInfo.Split("`n") | Select-String 'ProductVersion') -Split(":")).Trim()[1].Split(".")[2])
-                FilePrivatePart = ([int](($getItem.VersionInfo.Split("`n") | Select-String 'ProductVersion') -Split(":")).Trim()[1].Split(".")[3])
+                FileMajorPart = [int]$preCookedNetDllVersionInfo.Split(".")[0]
+                FileMinorPart = [int]$preCookedNetDllVersionInfo.Split(".")[1]
+                FileBuildPart = [int]$preCookedNetDllVersionInfo.Split(".")[2]
+                FilePrivatePart = [int]$preCookedNetDllVersionInfo.Split(".")[3]
             })
-
             $files.Add($filename, $cookedNetDllFileInfo)
         }
     }

--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -4947,6 +4947,7 @@ param(
         $Script:AnalyzedInformation = Add-AnalyzedResultInformation -Name "Security Vulnerability" -Details ("{0}`r`n`t`t`tSee: https://portal.msrc.microsoft.com/en-us/security-guidance/advisory/{0} for more information." -f "CVE-2020-1147") `
             -DisplayGroupingKey $keySecuritySettings `
             -DisplayWriteType "Red" `
+            -AddHtmlDetailRow $false `
             -AnalyzedInformation $Script:AnalyzedInformation
     }
 


### PR DESCRIPTION
Get-DotNetDllFileVersions returns now cooked values when Get-Item was executed against a remote computer. This PR replaces PR #377