### PR TITLE
Script displays all errors if not executed elevated in v3

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -5431,8 +5431,9 @@ Function Main {
         (-not $AnalyzeDataOnly -and
         -not $BuildHtmlServersReport))
 	{
-		Write-Warning "The script needs to be executed in elevated mode. Start the Exchange Management Shell as an Administrator." 
-		sleep 2;
+        Write-Warning "The script needs to be executed in elevated mode. Start the Exchange Management Shell as an Administrator."
+        $Script:ErrorStartCount = $Error.Count
+		Start-Sleep -Seconds 2;
 		exit
     }
 


### PR DESCRIPTION
To address issue #385 . We simply set `$Script:ErrorStartCount` to `$Error.Count` value to prevent any display output via `Finally ` block if the script is not executed in elevated context.