### PR TITLE
Fix for RSS state detection check v3

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -1692,6 +1692,7 @@ Function Get-AllNicInformation {
                     {
                         $false {$rssStateInt = 0}
                         $true {$rssStateInt = 1}
+                        default {$rssStateInt = 2}
                     }
                 }
                 catch


### PR DESCRIPTION
RSS detection was broken on v3. Added logic to query RSS state to `Get-NetworkConfiguration` method. 
We re-use the already opened cim session to query for each active network adapter the RSS state by using `Get-NetAdapterRss` cmdlet. We then expand the existing `$networkIpConfiguration` object by using Add-Member and place the Rss state in there.