### PR TITLE
Get-ServerOperatingSystemVersion improvements v3

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -387,7 +387,8 @@ using System.Collections;
             Windows2012,
             Windows2012R2,
             Windows2016,
-            Windows2019
+            Windows2019,
+            WindowsCore
         }
     
         public class NICInformation 
@@ -1574,6 +1575,8 @@ Function Get-ServerOperatingSystemVersion {
         "*Server 2012*" {$osReturnValue = "Windows2012"}
         "*Server 2016*" {$osReturnValue = "Windows2016"}
         "*Server 2019*" {$osReturnValue = "Windows2019"}
+        "Microsoft Windows Server Standard" {$osReturnValue = "WindowsCore"}
+        "Microsoft Windows Server Datacenter" {$osReturnValue = "WindowsCore"}
         default {$osReturnValue = "Unknown"}
     }
     


### PR DESCRIPTION
Added `WindowsCore `to make sure that `Get-ServerOperatingSystemVersion` returns a usable value even if the script is executed on or against Server Core. 
`Microsoft Windows Server Standard` or `Microsoft Windows Server Datacenter` is the returned OS caption on Windows Server 2016 and 2019 core. We should be good by doing it this way because Windows Server 2019 Core is the only supported Core OS version to run Exchange Server (2019).