### PR TITLE
Fix for Test-VulnerabilitiesByBuildNumbersForDisplay in v3

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -4765,7 +4765,10 @@ param(
             [int]$securityFixedBuildPart = ($split = $securityFixedBuild.Split("."))[0]
             [int]$securityFixedPrivatePart = $split[1]
 
-            if($fileBuildPart -eq $securityFixedBuildPart) { $Script:breakpointHit = $true }
+            if($fileBuildPart -eq $securityFixedBuildPart)
+            {
+                $Script:breakpointHit = $true
+            }
 
             if (($fileBuildPart -lt $securityFixedBuildPart) -or
                 ($fileBuildPart -eq $securityFixedBuildPart -and
@@ -4784,7 +4787,11 @@ param(
                 $Script:AllVulnerabilitiesPassed = $false
                 break
             }
-            if($Script:breakpointHit) { break }
+            
+            if($Script:breakpointHit)
+            {
+                break
+            }
         }
     }
 

--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -4758,11 +4758,14 @@ param(
     )
         [int]$fileBuildPart = ($split = $ExchangeBuildRevision.Split("."))[0]
         [int]$filePrivatePart = $split[1]
+        $Script:breakpointHit = $false
 
         foreach ($securityFixedBuild in $SecurityFixedBuilds)
         {
             [int]$securityFixedBuildPart = ($split = $securityFixedBuild.Split("."))[0]
             [int]$securityFixedPrivatePart = $split[1]
+
+            if($fileBuildPart -eq $securityFixedBuildPart) { $Script:breakpointHit = $true }
 
             if (($fileBuildPart -lt $securityFixedBuildPart) -or
                 ($fileBuildPart -eq $securityFixedBuildPart -and
@@ -4781,6 +4784,7 @@ param(
                 $Script:AllVulnerabilitiesPassed = $false
                 break
             }
+            if($Script:breakpointHit) { break }
         }
     }
 


### PR DESCRIPTION
**Issue:**
Reported: Yes
Issue ID: #406 

Test-VulnerabilitiesByBuildNumbersForDisplay was not working properly if the most current Cumulative Update (CU) was not installed.

Example:
Exchange 2016 CU17 with latest Security Updates (SU) reported vulnerable for `"CVE-2020-17083","CVE-2020-17084","CVE-2020-17085"`.
Exchange 2016 CU18 with latest SU does not.

Reason for this behavior is that the `foreach` loop is executed against all `SecurityFixedBuilds` and so reported vulnerable if the most current CU was not installed.

**Fix:**
Added a breakpoint to break the loop after the Build and Private Part check, if `$fileBuildPart -eq $securityFixedBuildPart`.
