### PR TITLE
Set-TlsMemberValue not working properly

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -2086,7 +2086,7 @@ Function Get-AllTlsSettingsFromRegistry {
     [Parameter(Mandatory=$true)][string]$MachineName,
     [Parameter(Mandatory=$false)][scriptblock]$CatchActionFunction
     )
-    #Function Version 1.0
+    #Function Version 1.1
     <# 
     Required Functions: 
         https://raw.githubusercontent.com/dpaulson45/PublicPowerShellScripts/master/Functions/Write-VerboseWriters/Write-VerboseWriter.ps1
@@ -2128,7 +2128,7 @@ Function Get-AllTlsSettingsFromRegistry {
                 }
              }
             "DisabledByDefault" {
-                if($KeyValue -ne $null)
+                if($KeyValue -eq $null)
                 {
                     Write-VerboseWriter("Failed to get TLS {0} {1} Disabled By Default Key on Server {2}. Setting to false." -f $TlsVersion, $ServerClientType, $MachineName)
                     return $false 


### PR DESCRIPTION
There is a logical issue for `DisabledByDefault` check.
First, we check if the passed key value `$KeyValue` is not `$null`. We then return `$false` and so, assuming that there was no valid value passed to `Set-TlsMemberValue`. Resulting in a false/positive. 