### PR TITLE
Multiplexor adapter PnP check improvements

### DIFF
--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -4398,25 +4398,22 @@ param(
             -AnalyzedInformation $analyzedResults
 
         #Assuming that all versions of Hyper-V doesn't allow sleepy NICs
-        if ($hardwareInformation.ServerType -ne [HealthChecker.ServerType]::HyperV)
+        if (($hardwareInformation.ServerType -ne [HealthChecker.ServerType]::HyperV) -and ($adapter.PnPCapabilities -ne "MultiplexorNoPnP"))
         {
             $displayWriteType = "Grey"
             $displayValue = $adapter.SleepyNicDisabled
 
-            if ((!$adapter.SleepyNicDisabled) -and ($adapter.PnPCapabilities -ne "MultiplexorNoPnP"))
+            if (!$adapter.SleepyNicDisabled)
             {
                 $displayWriteType = "Yellow"
                 $displayValue = "False --- Warning: It's recommended to disable NIC power saving options`r`n`t`t`tMore Information: http://support.microsoft.com/kb/2740020"
             }
 
-            if($adapter.PnPCapabilities -ne "MultiplexorNoPnP")
-            {
-                $analyzedResults = Add-AnalyzedResultInformation -Name "Sleepy NIC Disabled" -Details $displayValue `
-                    -DisplayGroupingKey $keyNICSettings `
-                    -DisplayWriteType $displayWriteType `
-                    -DisplayTestingValue $adapter.SleepyNicDisabled `
-                    -AnalyzedInformation $analyzedResults
-            }
+            $analyzedResults = Add-AnalyzedResultInformation -Name "Sleepy NIC Disabled" -Details $displayValue `
+                -DisplayGroupingKey $keyNICSettings `
+                -DisplayWriteType $displayWriteType `
+                -DisplayTestingValue $adapter.SleepyNicDisabled `
+                -AnalyzedInformation $analyzedResults
         }
 
         $adapterDescription = $adapter.Description

--- a/HealthChecker.ps1
+++ b/HealthChecker.ps1
@@ -1603,7 +1603,7 @@ Function Get-AllNicInformation {
     [Parameter(Mandatory=$false)][string]$ComputerFQDN,
     [Parameter(Mandatory=$false)][scriptblock]$CatchActionFunction
     )
-    #Function Version 1.5
+    #Function Version 1.6
     <# 
     Required Functions: 
         https://raw.githubusercontent.com/dpaulson45/PublicPowerShellScripts/master/Functions/Write-VerboseWriters/Write-VerboseWriter.ps1


### PR DESCRIPTION
First implementation to address #426 

We validate `$adapter.DriverFileName` in non-WMI scenario. If it's `NdisImPlatform.sys`, which is the `Microsoft Network Adapter Multiplexor Driver,` we skip the `Get-NicPnpCapabilitiesSetting` call and set `$nicPnpCapabilitiesSetting.PnPCapabilities` to `MultiplexorNoPnP`.

In WMI scenario, we validate `$adapter.ServiceName`. If it's `NdisImPlatformMp`, we also skip the `Get-NicPnpCapabilitiesSetting` call and set `$nicPnpCapabilitiesSetting.PnPCapabilities` to `MultiplexorNoPnP`.