### PR TITLE
Check for x86 PowerShell runtime environment added

### DIFF
--- a/src/HealthChecker/extern/Confirm-ExchangeShell.ps1
+++ b/src/HealthChecker/extern/Confirm-ExchangeShell.ps1
@@ -7,7 +7,7 @@ Function Confirm-ExchangeShell {
     [Parameter(Mandatory=$false)][bool]$ByPassLocalExchangeServerTest = $false,
     [Parameter(Mandatory=$false)][scriptblock]$CatchActionFunction
     )
-    #Function Version 1.6
+    #Function Version 1.7
     <#
     Required Functions: 
         https://raw.githubusercontent.com/dpaulson45/PublicPowerShellScripts/master/Functions/Write-HostWriters/Write-HostWriter.ps1
@@ -18,8 +18,12 @@ Function Confirm-ExchangeShell {
     Write-VerboseWriter("Calling: Confirm-ExchangeShell")
     Write-VerboseWriter("Passed: [bool]LoadExchangeShell: {0} | [bool]LoadExchangeVariables: {1} | [bool]ByPassLocalExchangeServerTest: {2}" -f $LoadExchangeShell,
     $LoadExchangeVariables, $ByPassLocalExchangeServerTest)
-    #Test that we are on Exchange 2010 or newer
-    if(($isLocalExchangeServer = (Test-Path 'HKLM:\SOFTWARE\Microsoft\ExchangeServer\v14\Setup')) -or
+    #Test that we are on Exchange 2010 or newer and not using x86 PowerShell to run the script
+    if(!([Environment]::Is64BitProcess))
+    {
+        Write-Yellow("Script was executed using x86 PowerShell which isn't supported. Please use x64 PowerShell.")
+    }
+    elseif(($isLocalExchangeServer = (Test-Path 'HKLM:\SOFTWARE\Microsoft\ExchangeServer\v14\Setup')) -or
     ($isLocalExchangeServer = (Test-Path 'HKLM:\SOFTWARE\Microsoft\ExchangeServer\v15\Setup')) -or
     $ByPassLocalExchangeServerTest)
     {


### PR DESCRIPTION
We're now checking if the script was executing within an x86 PowerShell runtime environment to address #442 