### PR TITLE
Fix for empty certificate object in v3

### DIFF
--- a/src/Analyzer/Start-AnalyzerEngine.ps1
+++ b/src/Analyzer/Start-AnalyzerEngine.ps1
@@ -1249,7 +1249,8 @@ param(
         }
     }
 
-    if($exchangeInformation.ExchangeCertificates.IsCurrentAuthConfigCertificate.Contains($true))
+    if(($null -ne $exchangeInformation.ExchangeCertificates) -and
+       ($exchangeInformation.ExchangeCertificates.IsCurrentAuthConfigCertificate.Contains($true)))
     {
         $analyzedResults = Add-AnalyzedResultInformation -Name "Valid Auth Certificate Found On Server" -Details $true `
         -DisplayGroupingKey $keySecuritySettings `


### PR DESCRIPTION
To address issue #436 .

We validate if `$exchangeInformation.ExchangeCertificates` is not `$null` before checking if `$exchangeInformation.ExchangeCertificates.IsCurrentAuthConfigCertificate.Contains($true)`