### PR TITLE
New function: Get-ExchangeBuildNumberFromString

### DIFF
--- a/src/Analyzer/Start-AnalyzerEngine.ps1
+++ b/src/Analyzer/Start-AnalyzerEngine.ps1
@@ -73,6 +73,16 @@ param(
             -AnalyzedInformation $analyzedResults
     }
 
+    if ($null -ne $exchangeInformation.BuildInformation.LocalBuildNumber)
+    {
+        $analyzedResults = Add-AnalyzedResultInformation -Name "Warning" -Details ("Exchange Build: {0} on the local server is older than the Build on the server that was queried." -f $exchangeInformation.BuildInformation.LocalBuildNumber) `
+            -DisplayGroupingKey $keyExchangeInformation `
+            -DisplayWriteType "Yellow" `
+            -DisplayCustomTabNumber 2 `
+            -AddHtmlDetailRow $false `
+            -AnalyzedInformation $analyzedResults  
+    }
+
     if ($exchangeInformation.BuildInformation.KBsInstalled -ne $null)
     {
         $analyzedResults = Add-AnalyzedResultInformation -Details ("Exchange IU or Security Hotfix Detected.") `

--- a/src/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/src/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -16,7 +16,11 @@ param(
     if($buildInformation.MajorVersion -ge [HealthChecker.ExchangeMajorVersion]::Exchange2013)
     {
         $netFrameworkExchange = $exchangeInformation.NETFramework
-        $adminDisplayVersion = $exchangeInformation.GetExchangeServer.AdminDisplayVersion
+        $adminDisplayVersion = Get-ExchangeBuildNumberFromString -AdminDisplayVersion $exchangeInformation.GetExchangeServer.AdminDisplayVersion
+        if($null -ne $adminDisplayVersion.LocalBuildNumber)
+        {
+            $buildInformation.LocalBuildNumber = $adminDisplayVersion.LocalBuildNumber
+        }
         $revisionNumber = if($adminDisplayVersion.Revision -lt 10) {$adminDisplayVersion.Revision / 10} else {$adminDisplayVersion.Revision / 100 }
         $buildAndRevision = $adminDisplayVersion.Build + $revisionNumber
         Write-VerboseOutput("The build and revision number: {0}" -f $buildAndRevision)

--- a/src/DataCollection/extern/Get-ExchangeBuildNumberFromString.ps1
+++ b/src/DataCollection/extern/Get-ExchangeBuildNumberFromString.ps1
@@ -1,0 +1,36 @@
+#Master Template: https://raw.githubusercontent.com/dpaulson45/PublicPowerShellScripts/master/Functions/Get-ExchangeBuildNumberFromString/Get-ExchangeBuildNumberFromString.ps1
+Function Get-ExchangeBuildNumberFromString {
+    [CmdletBinding()]
+    param(
+    [Parameter(Mandatory=$true)][object]$AdminDisplayVersion 
+    )
+    #Function Version 1.0
+    <# 
+    Required Functions: 
+        https://raw.githubusercontent.com/dpaulson45/PublicPowerShellScripts/master/Functions/Write-VerboseWriters/Write-VerboseWriter.ps1
+    #>
+    Write-VerboseWriter("Calling: Get-ExchangeBuildNumberFromString")
+    Write-VerboseWriter("Passed: {0}" -f $AdminDisplayVersion.ToString())
+    if($AdminDisplayVersion.GetType().Name -eq "string")
+    {
+        Write-VerboseWriter("AdminDisplayNumber string object detected. Converting into useable PSCustomObject")
+        $versionNumber = (($AdminDisplayVersion.split("()") -replace "Version|Build","").split(".")).trim()
+        Write-VerboseWriter("Trying to get local systems version number")
+        $localVersionNumber = Get-Command ExSetup | ForEach-Object{$_.FileVersionInfo}
+
+        $adminDisplayVersionObj = [PSCustomObject]@{
+            Major = [int]$versionNumber[0]
+            Minor = [int]$versionNumber[1]
+            Build = [int]$versionNumber[2]
+            Revision = [int]$versionNumber[3]
+            LocalBuildNumber = $localVersionNumber.FileVersionRaw.ToString()
+        }
+    }
+    else 
+    {
+        Write-VerboseWriter("Usable AdminDisplayNumber object passed. Nothing to do here")
+        $adminDisplayVersionObj = $AdminDisplayVersion
+    }
+    
+    return $adminDisplayVersionObj
+}

--- a/src/HealthChecker/Class.ps1
+++ b/src/HealthChecker/Class.ps1
@@ -34,7 +34,8 @@ try {
                 public ExchangeMajorVersion MajorVersion; //Exchange Version (Exchange 2010/2013/2019)
                 public ExchangeCULevel CU;             // Exchange CU Level 
                 public string FriendlyName;     //Exchange Friendly Name is provided
-                public string BuildNumber;      //Exchange Build Number 
+                public string BuildNumber;      //Exchange Build Number
+                public string LocalBuildNumber; //Build number of the server where the script is executed (e.g. server with Exchange tools) 
                 public string ReleaseDate;      // Exchange release date for which the CU they are currently on
                 public bool SupportedBuild;     //Determines if we are within the correct build of Exchange.
                 public object ExchangeSetup;    //Stores the Get-Command ExSetup object


### PR DESCRIPTION
To address issue #438 and to implement a warning as discussed in #440 