### PR TITLE
Address a terminating issue in case of a not initialized or null array for Exchange AppPools

### DIFF
--- a/src/HealthChecker/Class.ps1
+++ b/src/HealthChecker/Class.ps1
@@ -22,7 +22,7 @@ try {
                 public ExchangeNetFrameworkInformation NETFramework = new ExchangeNetFrameworkInformation(); 
                 public bool MapiHttpEnabled; //Stored from organization config 
                 public string ExchangeServicesNotRunning; //Contains the Exchange services not running by Test-ServiceHealth 
-                public Hashtable ApplicationPools;
+                public Hashtable ApplicationPools = new Hashtable();
                 public ExchangeRegistryValues RegistryValues = new ExchangeRegistryValues();
                 public ExchangeServerMaintenance ServerMaintenance;
                 public System.Array ExchangeCertificates;           //stores all the Exchange certificates on the servers. 


### PR DESCRIPTION
This fix prevents the script from aborting because of an indexing null array issue as reported in #449.
We now check if `$exchangeInformation.ApplicationPools` is not `$null` before we go on with the `MSExchangeMapiFrontEndAppPool` logic. We assume that `MSExchangeMapiFrontEndAppPool` exists in any case if `$exchangeInformation.ApplicationPools` is not `$null`. 