### PR TITLE
Added Script Build Date to the Build Script and don't check for a new…

### DIFF
--- a/.build/Invoke-BuildScript.ps1
+++ b/.build/Invoke-BuildScript.ps1
@@ -53,6 +53,12 @@ $scriptFiles | ForEach-Object {
             $scriptContent.RemoveAt($i)
             $scriptContent.Insert($i, "`$scriptVersion = `"$NewScriptVersion`"")
         }
+
+        if ($line -eq '$scriptBuildDate = "Today"') {
+            $scriptContent.RemoveAt($i)
+            $today = Get-Date
+            $scriptContent.Insert($i, "`$scriptBuildDate = `"$today`"")
+        }
     }
 
     $outputLocation = ([IO.Path]::Combine($distFolder, [IO.Path]::GetFileName($_)))

--- a/src/HealthChecker.ps1
+++ b/src/HealthChecker.ps1
@@ -110,6 +110,7 @@ param(
 )
 
 $scriptVersion = "1.0.0"
+$scriptBuildDate = "Today"
 
 $VirtualizationWarning = @"
 Virtual Machine detected.  Certain settings about the host hardware cannot be detected from the virtual machine.  Verify on the VM Host that:

--- a/src/Writers/Write-HealthCheckerVersion.ps1
+++ b/src/Writers/Write-HealthCheckerVersion.ps1
@@ -1,10 +1,12 @@
 Function Write-HealthCheckerVersion {
 
-    $currentVersion = Test-ScriptVersion -ApiUri "api.github.com" -RepoOwner "dpaulson45" `
-        -RepoName "HealthChecker" `
-        -CurrentVersion $scriptVersion `
-        -DaysOldLimit 90 `
-        -CatchActionFunction ${Function:Invoke-CatchActions}
+    if (([DateTime]::Parse($scriptBuildDate)).AddDays(10) -lt [DateTime]::Now) {
+        $currentVersion = Test-ScriptVersion -ApiUri "api.github.com" -RepoOwner "dpaulson45" `
+            -RepoName "HealthChecker" `
+            -CurrentVersion $scriptVersion `
+            -DaysOldLimit 90 `
+            -CatchActionFunction ${Function:Invoke-CatchActions}
+    } else { $currentVersion = $true }
 
     $Script:DisplayedScriptVersionAlready = $true
 


### PR DESCRIPTION
Added Script Build Date to the Build Script and don't check for a newer script if built within 10 days

This helps cut down on testing as well as a pointless check if they just downloaded a new release.

Resolved #465 