### PR TITLE
Improvements for better localhost experience

### DIFF
--- a/src/DataCollection/extern/Get-AllNicInformation.ps1
+++ b/src/DataCollection/extern/Get-AllNicInformation.ps1
@@ -61,8 +61,16 @@ Function Get-AllNicInformation {
         )
         try {
             $currentErrors = $Error.Count
-            $cimSession = New-CimSession -ComputerName $ComputerName -ErrorAction Stop
-            $networkIpConfiguration = Get-NetIPConfiguration -CimSession $CimSession -ErrorAction Stop | Where-Object { $_.NetAdapter.MediaConnectionState -eq "Connected" }
+            $params = @{
+                ErrorAction = "Stop"
+            }
+            if(($ComputerName).Split(".")[0] -ne $env:COMPUTERNAME)
+            {
+                $cimSession = New-CimSession -ComputerName $ComputerName -ErrorAction Stop
+                $params.Add("CimSession", $CimSession)
+            }
+
+            $networkIpConfiguration = Get-NetIPConfiguration @params | Where-Object { $_.NetAdapter.MediaConnectionState -eq "Connected" }
 
             if ($null -ne $CatchActionFunction) {
                 $index = 0

--- a/src/DataCollection/extern/Invoke-ScriptBlockHandler.ps1
+++ b/src/DataCollection/extern/Invoke-ScriptBlockHandler.ps1
@@ -17,7 +17,7 @@ Function Invoke-ScriptBlockHandler {
         Write-VerboseWriter($ScriptBlockDescription)
     }
     try {
-        if ($ComputerName -ne $env:COMPUTERNAME) {
+        if (($ComputerName).Split(".")[0] -ne $env:COMPUTERNAME) {
             $params = @{
                 ComputerName = $ComputerName
                 ScriptBlock  = $ScriptBlock

--- a/src/Helpers/Test-RequiresServerFqdn.ps1
+++ b/src/Helpers/Test-RequiresServerFqdn.ps1
@@ -1,12 +1,21 @@
 Function Test-RequiresServerFqdn {
 
     Write-VerboseOutput("Calling: Test-RequiresServerFqdn")
-
-    try {
+    try
+    {
         $Script:ServerFQDN = (Get-ExchangeServer $Script:Server).FQDN
-        Invoke-Command -ComputerName $Script:Server -ScriptBlock { Get-Date | Out-Null } -ErrorAction Stop
-        Write-VerboseOutput("Connected successfully using NetBIOS name.")
-    } catch {
+        if($Script:Server -ne $env:COMPUTERNAME)
+        {
+            Invoke-Command -ComputerName $Script:Server -ScriptBlock {Get-Date | Out-Null} -ErrorAction Stop
+            Write-VerboseOutput("Connected successfully using NetBIOS name.")
+        }
+        else
+        {
+            Write-VerboseOutput("Executed against the local machine. No need to pass '-ComputerName' parameter.")
+        }
+    }
+    catch
+    {
         Invoke-CatchActions
         Write-VerboseOutput("Failed to connect to {0} using NetBIOS name. Fallback to Fqdn: {1}" -f $Script:Server, $Script:ServerFQDN)
         $Script:Server = $Script:ServerFQDN

--- a/src/Helpers/Test-RequiresServerFqdn.ps1
+++ b/src/Helpers/Test-RequiresServerFqdn.ps1
@@ -1,14 +1,54 @@
 Function Test-RequiresServerFqdn {
 
     Write-VerboseOutput("Calling: Test-RequiresServerFqdn")
+    try
+    {
+        $tempServerName = ($Script:Server).Split(".")
 
-    try {
-        $Script:ServerFQDN = (Get-ExchangeServer $Script:Server).FQDN
-        Invoke-Command -ComputerName $Script:Server -ScriptBlock { Get-Date | Out-Null } -ErrorAction Stop
-        Write-VerboseOutput("Connected successfully using NetBIOS name.")
-    } catch {
+        if($tempServerName.count -gt 1)
+        {
+            Write-VerboseOutput("Fqdn was passed using '-server' parameter")
+            $isFqdn = $true
+            $connectionMethod = "Fqdn"
+        }
+        else
+        {
+            Write-VerboseOutput("NetBIOS name was passed using '-server' parameter")
+            $connectionMethod = "NetBIOS name"
+            $Script:ServerFQDN = (Get-ExchangeServer $Script:Server).FQDN
+        }
+
+        if($tempServerName[0] -eq $env:COMPUTERNAME)
+        {
+            Write-VerboseOutput("Executed against the local machine. No need to pass '-ComputerName' parameter.")
+        }
+        else
+        {
+            try
+            {
+                Invoke-Command -ComputerName $Script:Server -ScriptBlock {Get-Date | Out-Null} -ErrorAction Stop
+                Write-VerboseOutput("Connected successfully using: {0}." -f $connectionMethod)
+            }
+            catch
+            {
+                Invoke-CatchActions
+                if($isFqdn)
+                {
+                    $newConnectionMethod = "NetBIOS name"
+                    $Script:Server = $tempServerName[0]
+                }
+                else
+                {
+                    $newConnectionMethod = "Fqdn"
+                    $Script:Server = $Script:ServerFQDN
+                }
+                Write-VerboseOutput("Failed to connect to: {0} using {1}. Fallback to: {2}" -f $Script:Server, $connectionMethod, $newConnectionMethod)
+            }
+        }
+    }
+    catch
+    {
         Invoke-CatchActions
-        Write-VerboseOutput("Failed to connect to {0} using NetBIOS name. Fallback to Fqdn: {1}" -f $Script:Server, $Script:ServerFQDN)
-        $Script:Server = $Script:ServerFQDN
+        Write-VerboseOutput("Failed to successfully run 'Test-RequiresServerFqdn'")
     }
 }

--- a/src/Helpers/Test-RequiresServerFqdn.ps1
+++ b/src/Helpers/Test-RequiresServerFqdn.ps1
@@ -1,21 +1,12 @@
 Function Test-RequiresServerFqdn {
 
     Write-VerboseOutput("Calling: Test-RequiresServerFqdn")
-    try
-    {
+
+    try {
         $Script:ServerFQDN = (Get-ExchangeServer $Script:Server).FQDN
-        if($Script:Server -ne $env:COMPUTERNAME)
-        {
-            Invoke-Command -ComputerName $Script:Server -ScriptBlock {Get-Date | Out-Null} -ErrorAction Stop
-            Write-VerboseOutput("Connected successfully using NetBIOS name.")
-        }
-        else
-        {
-            Write-VerboseOutput("Executed against the local machine. No need to pass '-ComputerName' parameter.")
-        }
-    }
-    catch
-    {
+        Invoke-Command -ComputerName $Script:Server -ScriptBlock { Get-Date | Out-Null } -ErrorAction Stop
+        Write-VerboseOutput("Connected successfully using NetBIOS name.")
+    } catch {
         Invoke-CatchActions
         Write-VerboseOutput("Failed to connect to {0} using NetBIOS name. Fallback to Fqdn: {1}" -f $Script:Server, $Script:ServerFQDN)
         $Script:Server = $Script:ServerFQDN


### PR DESCRIPTION
This PR contains a fix for issue #474 .
`Test-RequiresServerFqdn` was totally rewritten to detect if the script is executed against the local system. Furthermore this function can detect whether the `Fqdn ` or `NetBIOS name` was passed via `-server` parameter. We do a fallback to the other value when we're not able to connect using the initial (`Fqdn` or `NetBIOS name`) value.

It contains also an improvement for `Get-AllNicInformation` and `Invoke-ScriptBlockHandler`. If the script was executed against the local machine using `-server` parameter and passing `Fqdn`, the logic to detect if the execution is against the local machine  doesn't work. We now split the passed value (if possible) and checking the first part of it against `$env:Computername`.