### PR TITLE
Improvements for better local experience

### DIFF
--- a/src/Helpers/Test-RequiresServerFqdn.ps1
+++ b/src/Helpers/Test-RequiresServerFqdn.ps1
@@ -30,8 +30,8 @@ Function Test-RequiresServerFqdn {
             Invoke-Command -ComputerName $Script:Server -ScriptBlock { Get-Date | Out-Null } -ErrorAction Stop
             Write-VerboseOutput("Fallback to: {0} Connection was successfully established." -f $Script:Server)
         } catch {
-            Invoke-CatchActions
-            Write-VerboseOutput("Failed to successfully run 'Test-RequiresServerFqdn'")
+            Write-Red("Failed to run against: {0}. Please try to run the script locally on: {0} for results. " -f $Script:Server)
+            exit
         }
     }
 }


### PR DESCRIPTION
This PR contains a fix for issue #474 .
`Test-RequiresServerFqdn` was totally rewritten to detect if the script is executed against the local system. Furthermore this function can detect whether the `Fqdn` or `NetBIOS name` was passed via `-server` parameter. We do a fallback to the other value when we're not able to connect using the initial (`Fqdn` or `NetBIOS name`) value.