### PR TITLE
Updated External Functions Repo Location

### DIFF
--- a/.build/UpdateExternalFiles.ps1
+++ b/.build/UpdateExternalFiles.ps1
@@ -3,10 +3,10 @@
 $repoRoot = Get-Item "$PSScriptRoot\.."
 Write-Host $repoRoot
 $externReproRoot = "$PSScriptRoot\.externRepo"
-$reproPublicScripts = "$externReproRoot\PublicPowerShellScripts"
+$reproPublicScripts = "$externReproRoot\PublicPowerShellFunctions"
 $rootPath = "$repoRoot\src"
-$gitCloneUrl = 'https://github.com/dpaulson45/PublicPowerShellScripts.git'
-$lineHeader = '#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/'
+$gitCloneUrl = 'https://github.com/dpaulson45/PublicPowerShellFunctions.git'
+$lineHeader = '#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/'
 
 try {
     if (!(Test-Path $externReproRoot)) {

--- a/src/DataCollection/extern/Get-AllNicInformation.ps1
+++ b/src/DataCollection/extern/Get-AllNicInformation.ps1
@@ -1,5 +1,5 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/ComputerInformation/Get-AllNicInformation/Get-AllNicInformation.ps1
-#v21.01.21.0637
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-AllNicInformation/Get-AllNicInformation.ps1
+#v21.01.25.0238
 Function Get-AllNicInformation {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Just creating internal objects')]
     [CmdletBinding()]
@@ -8,7 +8,7 @@ Function Get-AllNicInformation {
         [Parameter(Mandatory = $false)][string]$ComputerFQDN,
         [Parameter(Mandatory = $false)][scriptblock]$CatchActionFunction
     )
-    #Function Version #v21.01.21.0637
+    #Function Version #v21.01.25.0238
 
     Write-VerboseWriter("Calling: Get-AllNicInformation")
     Write-VerboseWriter("Passed [string]ComputerName: {0} | [string]ComputerFQDN: {1}" -f $ComputerName, $ComputerFQDN)
@@ -61,8 +61,14 @@ Function Get-AllNicInformation {
         )
         try {
             $currentErrors = $Error.Count
-            $cimSession = New-CimSession -ComputerName $ComputerName -ErrorAction Stop
-            $networkIpConfiguration = Get-NetIPConfiguration -CimSession $CimSession -ErrorAction Stop | Where-Object { $_.NetAdapter.MediaConnectionState -eq "Connected" }
+            $params = @{
+                ErrorAction = "Stop"
+            }
+            if (($ComputerName).Split(".")[0] -ne $env:COMPUTERNAME) {
+                $cimSession = New-CimSession -ComputerName $ComputerName -ErrorAction Stop
+                $params.Add("CimSession", $cimSession)
+            }
+            $networkIpConfiguration = Get-NetIPConfiguration @params | Where-Object { $_.NetAdapter.MediaConnectionState -eq "Connected" }
 
             if ($null -ne $CatchActionFunction) {
                 $index = 0

--- a/src/DataCollection/extern/Get-AllTlsSettingsFromRegistry.ps1
+++ b/src/DataCollection/extern/Get-AllTlsSettingsFromRegistry.ps1
@@ -1,5 +1,5 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/ComputerInformation/Get-AllTlsSettingsFromRegistry/Get-AllTlsSettingsFromRegistry.ps1
-#v21.01.08.2133
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-AllTlsSettingsFromRegistry/Get-AllTlsSettingsFromRegistry.ps1
+#v21.01.22.2234
 Function Get-AllTlsSettingsFromRegistry {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Just creating internal objects')]
     [CmdletBinding()]
@@ -8,7 +8,7 @@ Function Get-AllTlsSettingsFromRegistry {
         [Parameter(Mandatory = $true)][string]$MachineName,
         [Parameter(Mandatory = $false)][scriptblock]$CatchActionFunction
     )
-    #Function Version #v21.01.08.2133
+    #Function Version #v21.01.22.2234
 
     Write-VerboseWriter("Calling: Get-AllTlsSettingsFromRegistry")
     Write-VerboseWriter("Passed: [string]MachineName: {0}" -f $MachineName)

--- a/src/DataCollection/extern/Get-DotNetDllFileVersions.ps1
+++ b/src/DataCollection/extern/Get-DotNetDllFileVersions.ps1
@@ -1,5 +1,5 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/ComputerInformation/Get-DotNetDllFileVersions/Get-DotNetDllFileVersions.ps1
-#v21.01.08.2133
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-DotNetDllFileVersions/Get-DotNetDllFileVersions.ps1
+#v21.01.22.2234
 Function Get-DotNetDllFileVersions {
     [CmdletBinding()]
     [OutputType("System.Collections.Hashtable")]
@@ -8,7 +8,7 @@ Function Get-DotNetDllFileVersions {
         [array]$FileNames,
         [scriptblock]$CatchActionFunction
     )
-    #Function Version #v21.01.08.2133
+    #Function Version #v21.01.22.2234
 
     Write-VerboseWriter("Calling: Get-DotNetDllFileVersions")
 

--- a/src/DataCollection/extern/Get-ExchangeBuildVersionInformation.ps1
+++ b/src/DataCollection/extern/Get-ExchangeBuildVersionInformation.ps1
@@ -1,11 +1,11 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/ExchangeInformation/Get-ExchangeBuildVersionInformation/Get-ExchangeBuildVersionInformation.ps1
-#v21.01.12.2118
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ExchangeInformation/Get-ExchangeBuildVersionInformation/Get-ExchangeBuildVersionInformation.ps1
+#v21.01.22.2234
 Function Get-ExchangeBuildVersionInformation {
     [CmdletBinding()]
     param(
         [object]$AdminDisplayVersion
     )
-    #Function Version #v21.01.12.2118
+    #Function Version #v21.01.22.2234
 
     Write-VerboseWriter("Calling: Get-ExchangeBuildVersionInformation")
     Write-VerboseWriter("Passed $($AdminDisplayVersion.ToString())")

--- a/src/DataCollection/extern/Get-NETFrameworkVersion.ps1
+++ b/src/DataCollection/extern/Get-NETFrameworkVersion.ps1
@@ -1,5 +1,5 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/ComputerInformation/Get-NETFrameworkVersion/Get-NETFrameworkVersion.ps1
-#v21.01.08.2133
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-NETFrameworkVersion/Get-NETFrameworkVersion.ps1
+#v21.01.22.2234
 Function Get-NETFrameworkVersion {
     [CmdletBinding()]
     param(
@@ -7,7 +7,7 @@ Function Get-NETFrameworkVersion {
         [int]$NetVersionKey = -1,
         [scriptblock]$CatchActionFunction
     )
-    #Function Version #v21.01.08.2133
+    #Function Version #v21.01.22.2234
 
     Write-VerboseWriter("Calling: Get-NETFrameworkVersion")
     if ($NetVersionKey -eq -1) {

--- a/src/DataCollection/extern/Get-ProcessorInformation.ps1
+++ b/src/DataCollection/extern/Get-ProcessorInformation.ps1
@@ -1,12 +1,12 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/ComputerInformation/Get-ProcessorInformation/Get-ProcessorInformation.ps1
-#v21.01.08.2133
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-ProcessorInformation/Get-ProcessorInformation.ps1
+#v21.01.22.2234
 Function Get-ProcessorInformation {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)][string]$MachineName,
         [Parameter(Mandatory = $false)][scriptblock]$CatchActionFunction
     )
-    #Function Version #v21.01.08.2133
+    #Function Version #v21.01.22.2234
 
     Write-VerboseWriter("Calling: Get-ProcessorInformation")
     $wmiObject = Get-WmiObjectHandler -ComputerName $MachineName -Class "Win32_Processor" -CatchActionFunction $CatchActionFunction

--- a/src/DataCollection/extern/Get-ServerOperatingSystemVersion.ps1
+++ b/src/DataCollection/extern/Get-ServerOperatingSystemVersion.ps1
@@ -1,5 +1,5 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/ComputerInformation/Get-ServerOperatingSystemVersion/Get-ServerOperatingSystemVersion.ps1
-#v21.01.08.2133
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-ServerOperatingSystemVersion/Get-ServerOperatingSystemVersion.ps1
+#v21.01.22.2234
 Function Get-ServerOperatingSystemVersion {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWMICmdlet', '', Justification = 'Need it for old legacy servers')]
     [CmdletBinding()]
@@ -7,7 +7,7 @@ Function Get-ServerOperatingSystemVersion {
     param(
         [string]$OsCaption
     )
-    #Function Version #v21.01.08.2133
+    #Function Version #v21.01.22.2234
 
     if ($OsCaption -eq [string]::Empty -or
         $null -eq $OsCaption) {

--- a/src/DataCollection/extern/Get-ServerRebootPending.ps1
+++ b/src/DataCollection/extern/Get-ServerRebootPending.ps1
@@ -1,12 +1,12 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/ComputerInformation/Get-ServerRebootPending/Get-ServerRebootPending.ps1
-#v21.01.08.2133
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-ServerRebootPending/Get-ServerRebootPending.ps1
+#v21.01.22.2234
 Function Get-ServerRebootPending {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)][string]$ServerName,
         [Parameter(Mandatory = $false)][scriptblock]$CatchActionFunction
     )
-    #Function Version #v21.01.08.2133
+    #Function Version #v21.01.22.2234
 
     Function Get-PendingFileReboot {
         try {

--- a/src/DataCollection/extern/Get-ServerType.ps1
+++ b/src/DataCollection/extern/Get-ServerType.ps1
@@ -1,12 +1,12 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/ComputerInformation/Get-ServerType/Get-ServerType.ps1
-#v21.01.11.2243
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-ServerType/Get-ServerType.ps1
+#v21.01.22.2234
 Function Get-ServerType {
     [CmdletBinding()]
     [OutputType("System.String")]
     param(
         [Parameter(Mandatory = $true)][string]$ServerType
     )
-    #Function Version #v21.01.11.2243
+    #Function Version #v21.01.22.2234
 
     Write-VerboseWriter("Calling: Get-ServerType")
     $returnServerType = [string]::Empty

--- a/src/DataCollection/extern/Get-Smb1ServerSettings.ps1
+++ b/src/DataCollection/extern/Get-Smb1ServerSettings.ps1
@@ -1,12 +1,12 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/ComputerInformation/Get-Smb1ServerSettings/Get-Smb1ServerSettings.ps1
-#v21.01.08.2133
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-Smb1ServerSettings/Get-Smb1ServerSettings.ps1
+#v21.01.22.2234
 Function Get-Smb1ServerSettings {
     [CmdletBinding()]
     param(
         [string]$ServerName = $env:COMPUTERNAME,
         [scriptblock]$CatchActionFunction
     )
-    #Function Version #v21.01.08.2133
+    #Function Version #v21.01.22.2234
 
     Write-VerboseWriter("Calling: Get-Smb1ServerSettings")
     Write-VerboseWriter("Passed ServerName: {0}" -f $ServerName)

--- a/src/DataCollection/extern/Get-TimeZoneInformationRegistrySettings.ps1
+++ b/src/DataCollection/extern/Get-TimeZoneInformationRegistrySettings.ps1
@@ -1,12 +1,12 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/ComputerInformation/Get-TimeZoneInformationRegistrySettings/Get-TimeZoneInformationRegistrySettings.ps1
-#v21.01.08.2133
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Get-TimeZoneInformationRegistrySettings/Get-TimeZoneInformationRegistrySettings.ps1
+#v21.01.22.2234
 Function Get-TimeZoneInformationRegistrySettings {
     [CmdletBinding()]
     param(
         [string]$MachineName = $env:COMPUTERNAME,
         [scriptblock]$CatchActionFunction
     )
-    #Function Version #v21.01.08.2133
+    #Function Version #v21.01.22.2234
 
     Write-VerboseWriter("Calling: Get-TimeZoneInformationRegistrySettings")
     Write-VerboseWriter("Passed: [string]MachineName: {0}" -f $MachineName)

--- a/src/DataCollection/extern/Get-WmiObjectHandler.ps1
+++ b/src/DataCollection/extern/Get-WmiObjectHandler.ps1
@@ -1,5 +1,5 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/Common/Get-WmiObjectHandler/Get-WmiObjectHandler.ps1
-#v21.01.08.2133
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Get-WmiObjectHandler/Get-WmiObjectHandler.ps1
+#v21.01.22.2234
 Function Get-WmiObjectHandler {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWMICmdlet', '', Justification = 'This is what this function is for')]
     [CmdletBinding()]
@@ -10,7 +10,7 @@ Function Get-WmiObjectHandler {
         [Parameter(Mandatory = $false)][string]$Namespace,
         [Parameter(Mandatory = $false)][scriptblock]$CatchActionFunction
     )
-    #Function Version #v21.01.08.2133
+    #Function Version #v21.01.22.2234
 
     Write-VerboseWriter("Calling: Get-WmiObjectHandler")
     Write-VerboseWriter("Passed: [string]ComputerName: {0} | [string]Class: {1} | [string]Filter: {2} | [string]Namespace: {3}" -f $ComputerName, $Class, $Filter, $Namespace)

--- a/src/DataCollection/extern/Invoke-RegistryGetValue.ps1
+++ b/src/DataCollection/extern/Invoke-RegistryGetValue.ps1
@@ -1,5 +1,5 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/ComputerInformation/Invoke-RegistryGetValue/Invoke-RegistryGetValue.ps1
-#v21.01.08.2133
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ComputerInformation/Invoke-RegistryGetValue/Invoke-RegistryGetValue.ps1
+#v21.01.22.2234
 Function Invoke-RegistryGetValue {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseOutputTypeCorrectly', '', Justification = 'Multiple output types occur')]
     [CmdletBinding()]
@@ -12,7 +12,7 @@ Function Invoke-RegistryGetValue {
         [Parameter(Mandatory = $false)][object]$DefaultValue,
         [Parameter(Mandatory = $false)][scriptblock]$CatchActionFunction
     )
-    #Function Version #v21.01.08.2133
+    #Function Version #v21.01.22.2234
 
     Write-VerboseWriter("Calling: Invoke-RegistryGetValue")
     try {

--- a/src/DataCollection/extern/Invoke-ScriptBlockHandler.ps1
+++ b/src/DataCollection/extern/Invoke-ScriptBlockHandler.ps1
@@ -1,5 +1,5 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/Common/Invoke-ScriptBlockHandler/Invoke-ScriptBlockHandler.ps1
-#v21.01.08.2133
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Invoke-ScriptBlockHandler/Invoke-ScriptBlockHandler.ps1
+#v21.01.25.0238
 Function Invoke-ScriptBlockHandler {
     [CmdletBinding()]
     param(
@@ -10,14 +10,14 @@ Function Invoke-ScriptBlockHandler {
         [Parameter(Mandatory = $false)][bool]$IncludeNoProxyServerOption,
         [Parameter(Mandatory = $false)][scriptblock]$CatchActionFunction
     )
-    #Function Version #v21.01.08.2133
+    #Function Version #v21.01.25.0238
 
     Write-VerboseWriter("Calling: Invoke-ScriptBlockHandler")
     if (![string]::IsNullOrEmpty($ScriptBlockDescription)) {
         Write-VerboseWriter($ScriptBlockDescription)
     }
     try {
-        if ($ComputerName -ne $env:COMPUTERNAME) {
+        if (($ComputerName).Split(".")[0] -ne $env:COMPUTERNAME) {
             $params = @{
                 ComputerName = $ComputerName
                 ScriptBlock  = $ScriptBlock

--- a/src/extern/Confirm-Administrator.ps1
+++ b/src/extern/Confirm-Administrator.ps1
@@ -1,5 +1,5 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/Common/Confirm-Administrator/Confirm-Administrator.ps1
-#v21.01.08.2133
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Confirm-Administrator/Confirm-Administrator.ps1
+#v21.01.22.2212
 Function Confirm-Administrator {
     $currentPrincipal = New-Object Security.Principal.WindowsPrincipal( [Security.Principal.WindowsIdentity]::GetCurrent() )
 

--- a/src/extern/Confirm-ExchangeShell.ps1
+++ b/src/extern/Confirm-ExchangeShell.ps1
@@ -1,12 +1,12 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/ExchangeInformation/Confirm-ExchangeShell/Confirm-ExchangeShell.ps1
-#v21.01.12.2326
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/ExchangeInformation/Confirm-ExchangeShell/Confirm-ExchangeShell.ps1
+#v21.01.22.2234
 Function Confirm-ExchangeShell {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $false)][bool]$LoadExchangeShell = $true,
         [Parameter(Mandatory = $false)][scriptblock]$CatchActionFunction
     )
-    #Function Version #v21.01.12.2326
+    #Function Version #v21.01.22.2234
 
     Function Invoke-CatchActionErrorLoop {
         param(

--- a/src/extern/New-LoggerObject.ps1
+++ b/src/extern/New-LoggerObject.ps1
@@ -1,5 +1,5 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/Common/New-LoggerObject/New-LoggerObject.ps1
-#v21.01.15.1618
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/New-LoggerObject/New-LoggerObject.ps1
+#v21.01.22.2234
 Function New-LoggerObject {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'I prefer New here')]
     [CmdletBinding()]
@@ -15,7 +15,7 @@ Function New-LoggerObject {
         [Parameter(Mandatory = $false)][scriptblock]$HostFunctionCaller,
         [Parameter(Mandatory = $false)][scriptblock]$VerboseFunctionCaller
     )
-    #Function Version #v21.01.15.1618
+    #Function Version #v21.01.22.2234
 
     ########################
     #

--- a/src/extern/Write-HostWriter.ps1
+++ b/src/extern/Write-HostWriter.ps1
@@ -1,5 +1,5 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/Common/Write-HostWriters/Write-HostWriter.ps1
-#v21.01.08.2133
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Write-HostWriters/Write-HostWriter.ps1
+#v21.01.22.2212
 
 Function Write-HostWriter {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Need to use Write Host')]

--- a/src/extern/Write-ScriptMethodHostWriters.ps1
+++ b/src/extern/Write-ScriptMethodHostWriters.ps1
@@ -1,5 +1,5 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/Common/Write-HostWriters/Write-ScriptMethodHostWriter.ps1
-#v21.01.08.2133
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Write-HostWriters/Write-ScriptMethodHostWriter.ps1
+#v21.01.22.2212
 Function Write-ScriptMethodHostWriter {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Need to use Write Host')]
     param(

--- a/src/extern/Write-ScriptMethodVerboseWriter.ps1
+++ b/src/extern/Write-ScriptMethodVerboseWriter.ps1
@@ -1,5 +1,5 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/Common/Write-VerboseWriters/Write-ScriptMethodVerboseWriter.ps1
-#v21.01.08.2133
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Write-VerboseWriters/Write-ScriptMethodVerboseWriter.ps1
+#v21.01.22.2212
 Function Write-ScriptMethodVerboseWriter {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Need to use Write Host')]
     param(

--- a/src/extern/Write-VerboseWriter.ps1
+++ b/src/extern/Write-VerboseWriter.ps1
@@ -1,5 +1,5 @@
-#https://github.com/dpaulson45/PublicPowerShellScripts/blob/master/Functions/Common/Write-VerboseWriters/Write-VerboseWriter.ps1
-#v21.01.11.1818
+#https://github.com/dpaulson45/PublicPowerShellFunctions/blob/master/src/Common/Write-VerboseWriters/Write-VerboseWriter.ps1
+#v21.01.22.2212
 Function Write-VerboseWriter {
     param(
         [Parameter(Mandatory = $true)][string]$WriteString


### PR DESCRIPTION
The external public PowerShell functions moved to a different repo called "PublicPowerShellFunctions" instead of being in "PublicPowerShellScripts"