### PR TITLE
Some more certificate check improvements

### DIFF
--- a/src/Analyzer/Start-AnalyzerEngine.ps1
+++ b/src/Analyzer/Start-AnalyzerEngine.ps1
@@ -1135,10 +1135,12 @@ Function Start-AnalyzerEngine {
                 -AnalyzedInformation $analyzedResults
         }
 
-        $analyzedResults = Add-AnalyzedResultInformation -Name "Current Auth Certificate" -Details $certificate.IsCurrentAuthConfigCertificate `
-            -DisplayGroupingKey $keySecuritySettings `
-            -DisplayCustomTabNumber 2 `
-            -AnalyzedInformation $analyzedResults
+        if ($exchangeInformation.BuildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::Edge) {
+            $analyzedResults = Add-AnalyzedResultInformation -Name "Current Auth Certificate" -Details $certificate.IsCurrentAuthConfigCertificate `
+                -DisplayGroupingKey $keySecuritySettings `
+                -DisplayCustomTabNumber 2 `
+                -AnalyzedInformation $analyzedResults
+        }
 
         $analyzedResults = Add-AnalyzedResultInformation -Name "SAN Certificate" -Details $certificate.IsSanCertificate `
             -DisplayGroupingKey $keySecuritySettings `
@@ -1164,6 +1166,18 @@ Function Start-AnalyzerEngine {
             -DisplayGroupingKey $keySecuritySettings `
             -DisplayCustomTabNumber 1 `
             -DisplayWriteType "Green" `
+            -AnalyzedInformation $analyzedResults
+    } elseif ($exchangeInformation.BuildInformation.ServerRole -eq [HealthChecker.ExchangeServerRole]::Edge) {
+        $analyzedResults = Add-AnalyzedResultInformation -Name "Valid Auth Certificate Found On Server" -Details $false `
+            -DisplayGroupingKey $keySecuritySettings `
+            -DisplayCustomTabNumber 1 `
+            -DisplayWriteType "Yellow" `
+            -AnalyzedInformation $analyzedResults
+
+        $analyzedResults = Add-AnalyzedResultInformation -Details "We can't check for Auth Certificates on Edge Transport Servers" `
+            -DisplayGroupingKey $keySecuritySettings `
+            -DisplayCustomTabNumber 2 `
+            -DisplayWriteType "Yellow" `
             -AnalyzedInformation $analyzedResults
     } else {
         $analyzedResults = Add-AnalyzedResultInformation -Name "Valid Auth Certificate Found On Server" -Details $false `

--- a/src/DataCollection/ExchangeInformation/Get-ExchangeServerCertificates.ps1
+++ b/src/DataCollection/ExchangeInformation/Get-ExchangeServerCertificates.ps1
@@ -21,9 +21,22 @@ Function Get-ExchangeServerCertificates {
                     $certificateLifetime = ([DateTime]($cert.NotAfter) - (Get-Date)).Days
                     $sanCertificateInfo = $false
 
+                    $currentErrors = $Error.Count
                     if ($null -ne $cert.DnsNameList -and
                         ($cert.DnsNameList).Count -gt 1) {
                         $sanCertificateInfo = $true
+                        $certDnsNameList = $cert.DnsNameList
+                    } elseif ($null -eq $cert.DnsNameList) {
+                        $certDnsNameList = "None"
+                    } else {
+                        $certDnsNameList = $cert.DnsNameList
+                    }
+                    if ($currentErrors -lt $Error.Count) {
+                        $i = 0
+                        while ($i -lt ($Error.Count - $currentErrors)) {
+                            Invoke-CatchActions $Error[$i]
+                            $i++
+                        }
                     }
 
                     if ($authConfigDetected) {
@@ -37,7 +50,7 @@ Function Get-ExchangeServerCertificates {
                     }
 
                     if ([String]::IsNullOrEmpty($cert.FriendlyName)) {
-                        $certFriendlyName = $cert.DnsNameList[0].Unicode
+                        $certFriendlyName = ($certDnsNameList[0]).ToString()
                     } else {
                         $certFriendlyName = $cert.FriendlyName
                     }
@@ -47,7 +60,7 @@ Function Get-ExchangeServerCertificates {
                     $certInformationObj | Add-Member -MemberType NoteProperty -Name "Thumbprint" -Value $cert.Thumbprint
                     $certInformationObj | Add-Member -MemberType NoteProperty -Name "PublicKeySize" -Value $cert.PublicKey.Key.KeySize
                     $certInformationObj | Add-Member -MemberType NoteProperty -Name "IsSanCertificate" -Value $sanCertificateInfo
-                    $certInformationObj | Add-Member -MemberType NoteProperty -Name "Namespaces" -Value $cert.DnsNameList
+                    $certInformationObj | Add-Member -MemberType NoteProperty -Name "Namespaces" -Value $certDnsNameList
                     $certInformationObj | Add-Member -MemberType NoteProperty -Name "Services" -Value $cert.Services
                     $certInformationObj | Add-Member -MemberType NoteProperty -Name "IsCurrentAuthConfigCertificate" -Value $isAuthConfigInfo
                     $certInformationObj | Add-Member -MemberType NoteProperty -Name "LifetimeInDays" -Value $certificateLifetime


### PR DESCRIPTION
To address issue: #493 
Furthermore, we don't output any more information about the Auth Config certificate if the script was executed on `EdgeTransport` (because there is no `Get-AuthConfig` cmdlet available which we need to validate the configured Auth Config certificate).
