### PR TITLE
AD Site name improvement

### DIFF
--- a/src/Analyzer/Start-AnalyzerEngine.ps1
+++ b/src/Analyzer/Start-AnalyzerEngine.ps1
@@ -110,7 +110,7 @@ Function Start-AnalyzerEngine {
             -AnalyzedInformation $analyzedResults
     }
 
-    $analyzedResults = Add-AnalyzedResultInformation -Name "AD Site" -Details ($exchangeInformation.GetExchangeServer.Site.Name) `
+    $analyzedResults = Add-AnalyzedResultInformation -Name "AD Site" -Details ([System.Convert]::ToString(($exchangeInformation.GetExchangeServer.Site)).Split("/")[-1]) `
         -DisplayGroupingKey $keyExchangeInformation `
         -AnalyzedInformation $analyzedResults
 


### PR DESCRIPTION
Fix for issue #503 
We convert this to string, split it ("/") and use the last part [-1]. This works on outdated tool machines, via PSSession as well as for full blown Exchange servers.
