### PR TITLE
Fix LB report on tools machine

### DIFF
--- a/src/Features/Get-CasLoadBalancingReport.ps1
+++ b/src/Features/Get-CasLoadBalancingReport.ps1
@@ -28,7 +28,7 @@ Function Get-CASLoadBalancingReport {
         $CASServers = Get-ExchangeServer | Where-Object { `
             ($_.IsClientAccessServer -eq $true) -and `
             ($_.AdminDisplayVersion -Match "^Version 15") -and `
-            ($_.Site.Name -eq $SiteName) }
+            ([System.Convert]::ToString($_.Site).Split("/")[-1] -eq $SiteName) }
     } else {
         Write-Grey("Site filtering OFF.  All Exchange 2013/2016 CAS servers will be used in the report.")
         $CASServers = Get-ExchangeServer | Where-Object { ($_.IsClientAccessServer -eq $true) -and ($_.AdminDisplayVersion -Match "^Version 15") }

--- a/src/Helpers/Set-ScriptLogFileLocation.ps1
+++ b/src/Helpers/Set-ScriptLogFileLocation.ps1
@@ -25,7 +25,8 @@ Function Set-ScriptLogFileLocation {
     }
 
     if ($Script:ExchangeShellComputer.ToolsOnly -and
-        $env:COMPUTERNAME -eq $Script:Server) {
+        $env:COMPUTERNAME -eq $Script:Server -and
+        !($LoadBalancingReport)) {
         Write-Yellow("Can't run Exchange Health Checker Against a Tools Server. Use the -Server Parameter and provide the server you want to run the script against.")
         exit
     }


### PR DESCRIPTION
Fix for issue #500 

LoadBalancing report was not running via `New-PSSession` or on management servers (EMS only). `SiteName` parameter was also not handled correctly on outdated management machines or via `New-PSSession`.