### PR TITLE
Use Win32_PhysicalMemory to query system memory

### DIFF
--- a/src/Analyzer/Start-AnalyzerEngine.ps1
+++ b/src/Analyzer/Start-AnalyzerEngine.ps1
@@ -315,10 +315,10 @@ Function Start-AnalyzerEngine {
         $displayValue = "Multiple page files detected. `r`n`t`tError: This has been know to cause performance issues please address this."
         $displayWriteType = "Red"
     } elseif ($exchangeInformation.BuildInformation.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2019) {
-        $testingValue.RecommendedPageFile = ($recommendedPageFileSize = [Math]::Truncate(($totalPhysicalMemory / 1MB) / 4))
+        $testingValue.RecommendedPageFile = ($recommendedPageFileSize = [Math]::Round(($totalPhysicalMemory / 1MB) / 4))
         Write-VerboseOutput("Recommended Page File Size: {0}" -f $recommendedPageFileSize)
         if ($recommendedPageFileSize -ne $maxPageSize) {
-            $displayValue = "{0}MB `r`n`t`tWarning: Page File is not set to 25% of the Total System Memory which is {1}MB. Recommended is {2}MB" -f $maxPageSize, ([Math]::Truncate($totalPhysicalMemory / 1MB)), $recommendedPageFileSize
+            $displayValue = "{0}MB `r`n`t`tWarning: Page File is not set to 25% of the Total System Memory which is {1}MB. Recommended is {2}MB" -f $maxPageSize, ([Math]::Round($totalPhysicalMemory / 1MB)), $recommendedPageFileSize
         } else {
             $displayValue = "{0}MB" -f $recommendedPageFileSize
             $displayWriteType = "Grey"

--- a/src/DataCollection/ServerInformation/Get-HardwareInformation.ps1
+++ b/src/DataCollection/ServerInformation/Get-HardwareInformation.ps1
@@ -4,10 +4,13 @@ Function Get-HardwareInformation {
 
     [HealthChecker.HardwareInformation]$hardware_obj = New-Object HealthChecker.HardwareInformation
     $system = Get-WmiObjectHandler -ComputerName $Script:Server -Class "Win32_ComputerSystem" -CatchActionFunction ${Function:Invoke-CatchActions}
+    $hardware_obj.MemoryInformation = Get-WmiObjectHandler -ComputerName $Script:Server -Class "Win32_PhysicalMemory" -CatchActionFunction ${Function:Invoke-CatchActions}
     $hardware_obj.Manufacturer = $system.Manufacturer
     $hardware_obj.System = $system
     $hardware_obj.AutoPageFile = $system.AutomaticManagedPagefile
-    $hardware_obj.TotalMemory = $system.TotalPhysicalMemory
+    ForEach ($memory in $hardware_obj.MemoryInformation) {
+        $hardware_obj.TotalMemory += $memory.Capacity
+    }
     $hardware_obj.ServerType = (Get-ServerType -ServerType $system.Manufacturer)
     $processorInformation = Get-ProcessorInformation -MachineName $Script:Server -CatchActionFunction ${Function:Invoke-CatchActions}
 

--- a/src/Helpers/Class.ps1
+++ b/src/Helpers/Class.ps1
@@ -300,7 +300,8 @@ try {
             {
                 public string Manufacturer; //String to display the hardware information
                 public ServerType ServerType; //Enum to determine if the hardware is VMware, HyperV, Physical, or Unknown
-                public double TotalMemory; //Stores the total memory available
+                public System.Array MemoryInformation; //Detailed information about the installed memory
+                public UInt64 TotalMemory; //Stores the total memory cooked value
                 public object System;   //object to store the system information that we have collected
                 public ProcessorInformation Processor;   //Detailed processor Information
                 public bool AutoPageFile; //True/False if we are using a page file that is being automatically set


### PR DESCRIPTION
**Issue:**
#506 - Pagefile check is inaccurate in some circumstances.

**Reason:**
We use the `Win32_ComputerSystem `class to get the `TotalPhysicalMemory `information. However, there is a known issue that the value returned may be inaccurate:

_Total size of physical memory. Be aware that, under some circumstances, this property may not return an accurate value for the physical memory. For example, it is not accurate if the BIOS is using some of the physical memory._

**Fix:**
Use the `Win32_PhysicalMemory` class to get accurate values.

**Validation:**
After the change the pagefile validation should work accurate.