### PR TITLE
Fix to display DAG name properly

### DIFF
--- a/src/Analyzer/Start-AnalyzerEngine.ps1
+++ b/src/Analyzer/Start-AnalyzerEngine.ps1
@@ -105,7 +105,7 @@ Function Start-AnalyzerEngine {
         -AnalyzedInformation $analyzedResults
 
     if ($exchangeInformation.BuildInformation.ServerRole -le [HealthChecker.ExchangeServerRole]::Mailbox) {
-        $analyzedResults = Add-AnalyzedResultInformation -Name "DAG Name" -Details ($exchangeInformation.GetMailboxServer.DatabaseAvailabilityGroup.Name) `
+        $analyzedResults = Add-AnalyzedResultInformation -Name "DAG Name" -Details ([System.Convert]::ToString($exchangeInformation.GetMailboxServer.DatabaseAvailabilityGroup)) `
             -DisplayGroupingKey $keyExchangeInformation `
             -AnalyzedInformation $analyzedResults
     }


### PR DESCRIPTION
**Issue:**
#503 - AD Site + DAG Name are not displayed properly on management machine

**Reason:**
We don't have the right object structure available on outdated tool servers (EMS) or via PSSession. Means we receive `$exchangeInformation.GetMailboxServer.DatabaseAvailabilityGroup` as `String` and so we don't have the Name property available.

**Fix:**
Use `[System.Convert]::ToString()` method to convert `$exchangeInformation.GetMailboxServer.DatabaseAvailabilityGroup` to `String`. This way the DAG Name is displayed correctly regardless of where the script is executed (Exchange Server, Tool Server, PSSession).

**Validation:**
After the change, the DAG Name is displayed properly.