### PR TITLE
Prevent Source Code Exe & Improve how to download

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 The Exchange Server Health Checker script helps detect common configuration issues that are known to cause performance issues and other long running issues that are caused by a simple configuration change within an Exchange Environment. It also helps collect useful information of your server to help speed up the process of common information gathering of your server.
 
 # Download
-To download this script, download the latest version [here](https://github.com/dpaulson45/HealthChecker/releases)
+To download this script, download the latest version [here](http://aka.ms/ExHCDownload)
+
+Or go to the [Releases](https://github.com/dpaulson45/HealthChecker/releases) page and select `HealthChecker.ps1` asset to download.
 
 # How To Run
 This script **must** be run as Administrator in Exchange Management Shell on an Exchange Server. You can provide no parameters and the script will just run against the local server and provide the detail output of the configuration of the server.

--- a/src/HealthChecker.ps1
+++ b/src/HealthChecker.ps1
@@ -310,6 +310,12 @@ Function Main {
     }
 }
 
+if ($scriptBuildDate -eq "Today") {
+    Write-Error ("Script isn't built. Do not run source code directly.`r`nIf developer, follow build process.")
+    Write-Host("`r`n`r`nDownload Built Script: http://aka.ms/ExHCDownload")
+    exit
+}
+
 try {
     $Script:Logger = New-LoggerObject -LogName "HealthChecker-Debug" -LogDirectory $OutputFilePath -VerboseEnabled $Script:VerboseEnabled -EnableDateTime $false -ErrorAction SilentlyContinue
     Main


### PR DESCRIPTION
**Issue:**
Getting a few users emailing about failing the script because they are trying to run the source code vs the built out script.

**Reason:**
End User Confusion

**Fix:**
- If `$scriptBuildDate` is set to `"Today"` they are running the source code. Throw Error. 
- Updated README.md to download the script directly without going to the releases page.

Resolved #516 
