### PR TITLE
Skip Test-ServiceHealth for [HealthChecker.ExchangeServerRole]::None

### DIFF
--- a/src/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/src/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -353,7 +353,8 @@ Function Get-ExchangeInformation {
             -CatchActionFunction ${Function:Invoke-CatchActions}
         $exchangeInformation.ServerMaintenance = Get-ExchangeServerMaintenanceState -ComponentsToSkip "ForwardSyncDaemon", "ProvisioningRps"
 
-        if ($buildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::ClientAccess) {
+        if (($buildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::ClientAccess) -and
+            ($buildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::None)) {
             $exchangeInformation.ExchangeServicesNotRunning = Test-ServiceHealth -Server $Script:Server | ForEach-Object { $_.ServicesNotRunning }
         }
     } elseif ($buildInformation.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2010) {


### PR DESCRIPTION
**Issue:**
We should skip the Test-ServiceHealth call in case of `[HealthChecker.ExchangeServerRole]::None` as this causes the following issue (the same as for CAS only server): https://practical365.com/exchange-server/exchange-2013-test-servicehealth-error/

**Reason:**
Error reported by customer where no role could be determined (still under investigation)

**Fix:**
Exclude the check for `[HealthChecker.ExchangeServerRole]::None` in code.

**Validation:**
Possible Pester unit test. Validated in lab.