### PR TITLE
Supported Exchange versions added to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,18 @@ To download this script, download the latest version [here](https://aka.ms/ExHCD
 
 Or go to the [Releases](https://github.com/dpaulson45/HealthChecker/releases) page and select `HealthChecker.ps1` asset to download.
 
-# Required Permissions
+# Requirements
+### Supported Exchange Server Versions:
+The script can be used to validate the configuration of the following Exchange Server versions:
+- Exchange Server 2013
+- Exchange Server 2016
+- Exchange Server 2019
+
+You can use the latest v2 release to validate the configuration of `Exchange Server 2010`. Please note that this version is no longer maintained and some checks are not available.
+
+You can download the latest v2 release [here](https://aka.ms/ExHCDownloadv2)
+
+### Required Permissions:
 Please make sure that the account used is a member of the `Local Administrator` group. This should be fulfilled on Exchange servers by being a member of the  `Organization Management` group. However, if the group membership was adjusted or in case the script is executed on a non-Exchange system like a management server, you need to add your account to the `Local Administrator` group. You also need to be a member of the following groups:
 
 - Organization Management


### PR DESCRIPTION
**Issue:**
Supportability of the current script version was not clearly documented.

**Reason:**
Customers are trying to run the current v3 on Exchange 2010 which is not supported.

**Fix:**
Added the supported versions to `README.md` to better outline the supported versions. 

**Validation:**
N/A