### PR TITLE
Ability to detect March 2021 SU for outdated Exchange Server versions

### DIFF
--- a/src/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/src/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -349,6 +349,13 @@ Function Get-ExchangeInformation {
         $exchangeInformation.ApplicationConfigFileStatus = Get-ExchangeApplicationConfigurationFileValidation -ConfigFileLocation ("{0}EdgeTransport.exe.config" -f $serverExchangeBinDirectory)
 
         $buildInformation.KBsInstalled = Get-ExchangeUpdates -ExchangeMajorVersion $buildInformation.MajorVersion
+        if (($null -ne $buildInformation.KBsInstalled) -and ($buildInformation.KBsInstalled -like "*KB5000871*")) {
+            Write-VerboseOutput("March 2021 SU: KB5000871 was detected on the system")
+            $buildInformation.March2021SUInstalled = $true
+        } else {
+            Write-VerboseOutput("March 2021 SU: KB5000871 was not detected on the system")
+            $buildInformation.March2021SUInstalled = $false
+        }
         $exchangeInformation.RegistryValues.CtsProcessorAffinityPercentage = Invoke-RegistryGetValue -MachineName $Script:Server `
             -SubKey "SOFTWARE\Microsoft\ExchangeServer\v15\Search\SystemParameters" `
             -GetValue "CtsProcessorAffinityPercentage" `

--- a/src/Helpers/Class.ps1
+++ b/src/Helpers/Class.ps1
@@ -42,6 +42,7 @@ try {
                 public bool SupportedBuild;     //Determines if we are within the correct build of Exchange.
                 public object ExchangeSetup;    //Stores the Get-Command ExSetup object
                 public System.Array KBsInstalled;  //Stored object IU or Security KB fixes
+                public bool March2021SUInstalled;    //True if March 2021 SU is installed
             }
 
             public class ExchangeNetFrameworkInformation


### PR DESCRIPTION
**Issue:**
We provide Security Updates (SUs) for unsupported Exchange bits (CUs) to address the vulnerabilities which were used in the Hafnium attack chain:
https://techcommunity.microsoft.com/t5/exchange-team-blog/march-2021-exchange-server-security-updates-for-older-cumulative/ba-p/2192020

These update packages contain only fixes for March 2021 CVEs (CVE-2021-26855, CVE-2021-26857, CVE-2021-26858, CVE-2021-27065); **no other product updates or security fixes are included**.

**Reason:**
We use the Exchange build numbers to detect if an installed build is vulnerable to any known vulnerability. However, we can't clearly detect if any other SU is in place because the build numbers of these 'special' March 2021 SUs are higher than the build numbers of previous SUs for these outdated CUs. 

**Fix:**
We check if the Hafnium SU is in place and if the system is running an outdated CU. If that's the case, we then show a warning like this to make the user aware that an update may still need to be installed:

![image](https://user-images.githubusercontent.com/40993616/110498757-e3ad6080-80f7-11eb-839b-f0956c7f11e6.png)

**Validation:**
Validated in lab. Possible Pester unit test case.