### PR TITLE
March 2021 CUs added

### DIFF
--- a/src/Analyzer/Start-AnalyzerEngine.ps1
+++ b/src/Analyzer/Start-AnalyzerEngine.ps1
@@ -1537,6 +1537,10 @@ Function Start-AnalyzerEngine {
             Test-VulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision -SecurityFixedBuilds "1415.8", "1466.13", "1531.12", "1591.18", "1713.10", "1779.8", "1847.12", "1913.12", "1979.8", "2044.13", "2106.13", "2176.9" -CVENames "CVE-2021-26855", "CVE-2021-26857", "CVE-2021-26858", "CVE-2021-27065"
             Test-VulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision -SecurityFixedBuilds "2106.13", "2176.9" -CVENames "CVE-2021-26412", "CVE-2021-27078", "CVE-2021-26854"
         }
+
+        if ($exchangeCU -ge [HealthChecker.ExchangeCULevel]::CU20) {
+            Write-VerboseOutput("There are no known vulnerabilities in this Exchange Server Build.")
+        }
     } elseif ($exchangeInformation.BuildInformation.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2019) {
 
         if ($exchangeCU -le [HealthChecker.ExchangeCULevel]::CU1) {
@@ -1575,6 +1579,10 @@ Function Start-AnalyzerEngine {
             Test-VulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision -SecurityFixedBuilds "221.18", "330.11", "397.11", "464.15", "529.13", "595.8", "659.12", "721.13", "792.10" -CVENames "CVE-2021-26855", "CVE-2021-26857", "CVE-2021-26858", "CVE-2021-27065"
             Test-VulnerabilitiesByBuildNumbersForDisplay -ExchangeBuildRevision $buildRevision -SecurityFixedBuilds "721.13", "792.10" -CVENames "CVE-2021-26412", "CVE-2021-27078", "CVE-2021-26854"
         }
+
+        if ($exchangeCU -ge [HealthChecker.ExchangeCULevel]::CU9) {
+            Write-VerboseOutput("There are no known vulnerabilities in this Exchange Server Build.")
+        }
     } else {
         Write-VerboseOutput("Unknown Version of Exchange")
         $Script:AllVulnerabilitiesPassed = $false
@@ -1585,13 +1593,15 @@ Function Start-AnalyzerEngine {
     #Fix: Update to a supported CU and apply KB5000871
 
     if (($exchangeInformation.BuildInformation.March2021SUInstalled) -and ($exchangeInformation.BuildInformation.SupportedBuild -eq $false)) {
-        Write-VerboseOutput("Unable to check due to special March 2021 Exchange Security Update installed")
-        if ($exchangeInformation.BuildInformation.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2013) {
+        if (($exchangeInformation.BuildInformation.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2013) -and
+            ($exchangeCU -lt [HealthChecker.ExchangeCULevel]::CU23)) {
             Switch ($exchangeCU) {
                 ([HealthChecker.ExchangeCULevel]::CU21) { $KBCveComb = @{KB4340731 = "CVE-2018-8302"; KB4459266 = "CVE-2018-8265", "CVE-2018-8448"; KB4471389 = "CVE-2019-0586", "CVE-2019-0588" } }
                 ([HealthChecker.ExchangeCULevel]::CU22) { $KBCveComb = @{KB4487563 = "CVE-2019-0817", "CVE-2019-0858"; KB4503027 = "ADV190018" } }
             }
-        } elseif ($exchangeInformation.BuildInformation.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2016) {
+            $Script:AllVulnerabilitiesPassed = $false
+        } elseif (($exchangeInformation.BuildInformation.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2016) -and
+            ($exchangeCU -lt [HealthChecker.ExchangeCULevel]::CU18)) {
             Switch ($exchangeCU) {
                 ([HealthChecker.ExchangeCULevel]::CU8) { $KBCveComb = @{KB4073392 = "CVE-2018-0924", "CVE-2018-0940", "CVE-2018-0941"; KB4092041 = "CVE-2018-8151", "CVE-2018-8152", "CVE-2018-8153", "CVE-2018-8154", "CVE-2018-8159" } }
                 ([HealthChecker.ExchangeCULevel]::CU9) { $KBCveComb = @{KB4092041 = "CVE-2018-8151", "CVE-2018-8152", "CVE-2018-8153", "CVE-2018-8154", "CVE-2018-8159"; KB4340731 = "CVE-2018-8374", "CVE-2018-8302" } }
@@ -1604,7 +1614,9 @@ Function Start-AnalyzerEngine {
                 ([HealthChecker.ExchangeCULevel]::CU16) { $KBCveComb = @{KB4577352 = "CVE-2020-16875" } }
                 ([HealthChecker.ExchangeCULevel]::CU17) { $KBCveComb = @{KB4577352 = "CVE-2020-16875"; KB4581424 = "CVE-2020-16969"; KB4588741 = "CVE-2020-17083", "CVE-2020-17084", "CVE-2020-17085"; KB4593465 = "CVE-2020-17117", "CVE-2020-17132", "CVE-2020-17141", "CVE-2020-17142", "CVE-2020-17143" } }
             }
-        } elseif ($exchangeInformation.BuildInformation.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2019) {
+            $Script:AllVulnerabilitiesPassed = $false
+        } elseif (($exchangeInformation.BuildInformation.MajorVersion -eq [HealthChecker.ExchangeMajorVersion]::Exchange2019) -and
+            ($exchangeCU -lt [HealthChecker.ExchangeCULevel]::CU7)) {
             Switch ($exchangeCU) {
                 ([HealthChecker.ExchangeCULevel]::RTM) { $KBCveComb = @{KB4471389 = "CVE-2019-0586", "CVE-2019-0588"; KB4487563 = "CVE-2019-0817", "CVE-2019-0858"; KB4503027 = "ADV190018" } }
                 ([HealthChecker.ExchangeCULevel]::CU1) { $KBCveComb = @{KB4487563 = "CVE-2019-0817", "CVE-2019-0858"; KB4503027 = "ADV190018"; KB4509409 = "CVE-2019-1084", "CVE-2019-1137"; KB4515832 = "CVE-2019-1233", "CVE-2019-1266" } }
@@ -1614,13 +1626,13 @@ Function Start-AnalyzerEngine {
                 ([HealthChecker.ExchangeCULevel]::CU5) { $KBCveComb = @{KB4577352 = "CVE-2020-16875" } }
                 ([HealthChecker.ExchangeCULevel]::CU6) { $KBCveComb = @{KB4577352 = "CVE-2020-16875"; KB4581424 = "CVE-2020-16969"; KB4588741 = "CVE-2020-17083", "CVE-2020-17084", "CVE-2020-17085"; KB4593465 = "CVE-2020-17117", "CVE-2020-17132", "CVE-2020-17141", "CVE-2020-17142", "CVE-2020-17143" } }
             }
+            $Script:AllVulnerabilitiesPassed = $false
         } else {
-            Write-VerboseOutput("Unknown Version of Exchange with special March 2021 Exchange Security Update installed")
+            Write-VerboseOutput("No need to call 'Show-March2021SUOutdatedCUWarning'")
         }
         if ($null -ne $KBCveComb) {
             Show-March2021SUOutdatedCUWarning -KBCVEHT $KBCveComb
         }
-        $Script:AllVulnerabilitiesPassed = $false
     }
 
     #Description: Check for CVE-2020-0796 SMBv3 vulnerability

--- a/src/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/src/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -67,11 +67,15 @@ Function Get-ExchangeInformation {
                 $buildInformation.CU = [HealthChecker.ExchangeCULevel]::CU7
                 $buildInformation.FriendlyName += "CU7"
                 $buildInformation.ReleaseDate = "09/15/2020"
-                $buildInformation.SupportedBuild = $true
-            } elseif ($buildAndRevision -ge 792.3) {
+            } elseif ($buildAndRevision -lt 858.5) {
                 $buildInformation.CU = [HealthChecker.ExchangeCULevel]::CU8
                 $buildInformation.FriendlyName += "CU8"
                 $buildInformation.ReleaseDate = "12/15/2020"
+                $buildInformation.SupportedBuild = $true
+            } elseif ($buildAndRevision -ge 858.5) {
+                $buildInformation.CU = [HealthChecker.ExchangeCULevel]::CU9
+                $buildInformation.FriendlyName += "CU9"
+                $buildInformation.ReleaseDate = "03/16/2021"
                 $buildInformation.SupportedBuild = $true
             }
 
@@ -163,11 +167,15 @@ Function Get-ExchangeInformation {
                 $buildInformation.CU = [HealthChecker.ExchangeCULevel]::CU18
                 $buildInformation.FriendlyName += "CU18"
                 $buildInformation.ReleaseDate = "09/15/2020"
-                $buildInformation.SupportedBuild = $true
-            } elseif ($buildAndRevision -ge 2176.2) {
+            } elseif ($buildAndRevision -lt 2242.4) {
                 $buildInformation.CU = [HealthChecker.ExchangeCULevel]::CU19
                 $buildInformation.FriendlyName += "CU19"
                 $buildInformation.ReleaseDate = "12/15/2020"
+                $buildInformation.SupportedBuild = $true
+            } elseif ($buildAndRevision -ge 2242.4) {
+                $buildInformation.CU = [HealthChecker.ExchangeCULevel]::CU20
+                $buildInformation.FriendlyName += "CU20"
+                $buildInformation.ReleaseDate = "03/16/2021"
                 $buildInformation.SupportedBuild = $true
             }
 


### PR DESCRIPTION
**Issue:**
Added the March 2021 Exchange CUs for Exchange 2016 and Exchange 2019

**Reason:**
To keep the script current

**Fix:**
Checks for the latest CUs added; Exception for CUs added for which we provide a full March 2021 OOB SU

**Validation:**
Test lab. Possible Pester unit test case.