### PR TITLE
Write-HealthCheckerVersion fix for different regional settings (other than en-US)

### DIFF
--- a/src/Analyzer/Start-AnalyzerEngine.ps1
+++ b/src/Analyzer/Start-AnalyzerEngine.ps1
@@ -60,7 +60,7 @@ Function Start-AnalyzerEngine {
         -AnalyzedInformation $analyzedResults
 
     if ($exchangeInformation.BuildInformation.SupportedBuild -eq $false) {
-        $daysOld = ($date - ([System.Convert]::ToDateTime([DateTime]$exchangeInformation.BuildInformation.ReleaseDate))).Days
+        $daysOld = ($date - ([System.Convert]::ToDateTime([DateTime]$exchangeInformation.BuildInformation.ReleaseDate, [System.Globalization.DateTimeFormatInfo]::InvariantInfo))).Days
 
         $analyzedResults = Add-AnalyzedResultInformation -Name "Error" -Details ("Out of date Cumulative Update. Please upgrade to one of the two most recently released Cumulative Updates. Currently running on a build that is {0} days old." -f $daysOld) `
             -DisplayGroupingKey $keyExchangeInformation `

--- a/src/DataCollection/ExchangeInformation/Get-ExchangeServerCertificates.ps1
+++ b/src/DataCollection/ExchangeInformation/Get-ExchangeServerCertificates.ps1
@@ -18,7 +18,7 @@ Function Get-ExchangeServerCertificates {
             [array]$certObject = @()
             foreach ($cert in $exchangeServerCertificates) {
                 try {
-                    $certificateLifetime = ([DateTime]($cert.NotAfter) - (Get-Date)).Days
+                    $certificateLifetime = ([System.Convert]::ToDateTime($cert.NotAfter, [System.Globalization.DateTimeFormatInfo]::InvariantInfo) - (Get-Date)).Days
                     $sanCertificateInfo = $false
 
                     $currentErrors = $Error.Count

--- a/src/Writers/Write-HealthCheckerVersion.ps1
+++ b/src/Writers/Write-HealthCheckerVersion.ps1
@@ -1,6 +1,6 @@
 Function Write-HealthCheckerVersion {
 
-    if (([DateTime]::Parse($scriptBuildDate)).AddDays(10) -lt [DateTime]::Now) {
+    if (([DateTime]::Parse($scriptBuildDate, [System.Globalization.DateTimeFormatInfo]::InvariantInfo)).AddDays(10) -lt [DateTime]::Now) {
         $currentVersion = Test-ScriptVersion -ApiUri "api.github.com" -RepoOwner "dpaulson45" `
             -RepoName "HealthChecker" `
             -CurrentVersion $scriptVersion `


### PR DESCRIPTION
**Issue:**
Multiple users reporting the following issue for the latest release:

```
Exception calling "Parse" with "1" argument(s): "String was not recognized as a valid DateTime."
At C:\admin\HealthChecker.ps1:547 char:9
+     if (([DateTime]::Parse($scriptBuildDate)).AddDays(10) -lt [DateTime]::Now) {
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : FormatException
 
at Write-HealthCheckerVersion, C:\admin\HealthChecker.ps1: line 547
at Main, C:\admin\HealthChecker.ps1: line 5776
at <ScriptBlock>, C:\admin\HealthChecker.ps1: line 5817
at <ScriptBlock>, <No file>: line 1
```

**Reason:**
We run into this issue when converting the `$scriptBuildDate` string in `Write-HealthCheckerVersion` function.

`if (([DateTime]::Parse($scriptBuildDate)).AddDays(10) -lt [DateTime]::Now) {`

This may be a problem when the systems regional settings are set to a different value than EN (German, Russian). Not sure why we see this issue now because this function is in place for a long time without any changes. 

**Fix:**
Use the `DateTime.Parse Method` and use the `InvariantInfo` culture format:
https://docs.microsoft.com/en-us/dotnet/api/system.datetime.parse?view=net-5.0#System_DateTime_Parse_System_String_System_IFormatProvider_

_To prevent the difficulties in parsing data and time strings that are associated with changes in cultural data, you can parse date and time strings by using the invariant culture ..._

`if (([DateTime]::Parse($scriptBuildDate, [System.Globalization.DateTimeFormatInfo]::InvariantInfo)).AddDays(10) -lt [DateTime]::Now) {`

**Validation:**
Validated by different affected customers.