### PR TITLE
Exchange test services output improved

### DIFF
--- a/src/Analyzer/Start-AnalyzerEngine.ps1
+++ b/src/Analyzer/Start-AnalyzerEngine.ps1
@@ -105,7 +105,11 @@ Function Start-AnalyzerEngine {
         -AnalyzedInformation $analyzedResults
 
     if ($exchangeInformation.BuildInformation.ServerRole -le [HealthChecker.ExchangeServerRole]::Mailbox) {
-        $analyzedResults = Add-AnalyzedResultInformation -Name "DAG Name" -Details ([System.Convert]::ToString($exchangeInformation.GetMailboxServer.DatabaseAvailabilityGroup)) `
+        $dagName = [System.Convert]::ToString($exchangeInformation.GetMailboxServer.DatabaseAvailabilityGroup)
+        if ([System.String]::IsNullOrWhiteSpace($dagName)) {
+            $dagName = "Standalone Server"
+        }
+        $analyzedResults = Add-AnalyzedResultInformation -Name "DAG Name" -Details $dagName `
             -DisplayGroupingKey $keyExchangeInformation `
             -AnalyzedInformation $analyzedResults
     }
@@ -170,10 +174,17 @@ Function Start-AnalyzerEngine {
     Write-VerboseOutput("Working on results from Test-ServiceHealth")
     $servicesNotRunning = $exchangeInformation.ExchangeServicesNotRunning
     if ($null -ne $servicesNotRunning) {
-
-        $analyzedResults = Add-AnalyzedResultInformation -Name "Services Not Running" -Details $servicesNotRunning `
+        $analyzedResults = Add-AnalyzedResultInformation -Name "Services Not Running" `
             -DisplayGroupingKey $keyExchangeInformation `
             -AnalyzedInformation $analyzedResults
+
+        foreach ($stoppedService in $servicesNotRunning) {
+            $analyzedResults = Add-AnalyzedResultInformation -Details $stoppedService `
+                -DisplayGroupingKey $keyExchangeInformation `
+                -DisplayCustomTabNumber 2  `
+                -DisplayWriteType "Yellow" `
+                -AnalyzedInformation $analyzedResults
+        }
     }
 
     ##############################

--- a/src/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
+++ b/src/DataCollection/ExchangeInformation/Get-ExchangeInformation.ps1
@@ -386,7 +386,12 @@ Function Get-ExchangeInformation {
         if (($buildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::ClientAccess) -and
             ($buildInformation.ServerRole -ne [HealthChecker.ExchangeServerRole]::None)) {
             try {
-                $exchangeInformation.ExchangeServicesNotRunning = Test-ServiceHealth -Server $Script:Server -ErrorAction Stop | ForEach-Object { $_.ServicesNotRunning }
+                $testServiceHealthResults = Test-ServiceHealth -Server $Script:Server -ErrorAction Stop
+                foreach ($notRunningService in $testServiceHealthResults.ServicesNotRunning) {
+                    if ($exchangeInformation.ExchangeServicesNotRunning -notcontains $notRunningService) {
+                        $exchangeInformation.ExchangeServicesNotRunning += $notRunningService
+                    }
+                }
             } catch {
                 Write-VerboseOutput ("Failed to run Test-ServiceHealth")
                 Invoke-CatchActions

--- a/src/Helpers/Class.ps1
+++ b/src/Helpers/Class.ps1
@@ -22,7 +22,7 @@ try {
                 public object GetMailboxServer;       //Stores the Get-MailboxServer Object
                 public ExchangeNetFrameworkInformation NETFramework = new ExchangeNetFrameworkInformation();
                 public bool MapiHttpEnabled; //Stored from organization config
-                public string ExchangeServicesNotRunning; //Contains the Exchange services not running by Test-ServiceHealth
+                public System.Array ExchangeServicesNotRunning; //Contains the Exchange services not running by Test-ServiceHealth
                 public Hashtable ApplicationPools = new Hashtable();
                 public ExchangeRegistryValues RegistryValues = new ExchangeRegistryValues();
                 public ExchangeServerMaintenance ServerMaintenance;


### PR DESCRIPTION
**Issue:**
We show duplicate entries for stopped services in case they are marked as required for multiple roles like `MSExchangeADTopology` which is required by `Mailbox Server Role`, `Client Access Server Role` and `Hub Transport Server Role`. 

We also list them in one row because they are just added to a string object.

**Reason:**

- List each stopped service only once
- Highlight the output to get attention
- List the stopped services among each other

**Fix:**
- Changed `ExchangeServicesNotRunning` to `System.Array`
- Check for each stopped service if it's already included in `$exchangeInformation.ExchangeServicesNotRunning` and if not, add the service to the `System.Array`
- Output each stopped service in a row and show them in yellow

- Bonus for DAG Name output: We now display `Standalone Server` in case a mailbox server is not a DAG member.

**Validation:**
Validated in lab