### PR TITLE
Certificate status validation added

### DIFF
--- a/src/Analyzer/Start-AnalyzerEngine.ps1
+++ b/src/Analyzer/Start-AnalyzerEngine.ps1
@@ -1210,6 +1210,34 @@ Function Start-AnalyzerEngine {
                 -AnalyzedInformation $analyzedResults
         }
 
+        $certStatusWriteType = [string]::Empty
+
+        if ($null -ne $certificate.Status) {
+            Switch ($certificate.Status) {
+                ("Unknown") { $certStatusWriteType = "Yellow" }
+                ("Valid") { $certStatusWriteType = "Grey" }
+                ("Revoked") { $certStatusWriteType = "Red" }
+                ("DateInvalid") { $certStatusWriteType = "Red" }
+                ("Untrusted") { $certStatusWriteType = "Yellow" }
+                ("Invalid") { $certStatusWriteType = "Red" }
+                ("RevocationCheckFailure") { $certStatusWriteType = "Yellow" }
+                ("PendingRequest") { $certStatusWriteType = "Yellow" }
+                default { $certStatusWriteType = "Yellow" }
+            }
+
+            $analyzedResults = Add-AnalyzedResultInformation -Name "Certificate status" -Details $certificate.Status `
+                -DisplayGroupingKey $keySecuritySettings `
+                -DisplayCustomTabNumber 2 `
+                -DisplayWriteType $certStatusWriteType `
+                -AnalyzedInformation $analyzedResults
+        } else {
+            $analyzedResults = Add-AnalyzedResultInformation -Name "Certificate status" -Details "Unknown" `
+                -DisplayGroupingKey $keySecuritySettings `
+                -DisplayCustomTabNumber 2 `
+                -DisplayWriteType "Yellow" `
+                -AnalyzedInformation $analyzedResults
+        }
+
         if ($certificate.PublicKeySize -lt 2048) {
             $additionalDisplayValue = "It's recommended to use a key size of at least 2048 bit."
 


### PR DESCRIPTION
**Issue:**
We're now validating the status for each certificate. This can help us to detect situations when a certificate seems valid (not expired), but it is not (for example: certificate revoked). This situation can cause different issues (for example mail flow issue in Hybrid configuration). 

**Reason:**
To get a quick and easy overview over the status for each certificate used by Exchange server.

**Fix:**
Switch statement added to validate the retuned status and to set the `statusWriteType`. This should cover any status type returned by `Get-ExchangeServer` cmdlet. However, we set the `default` to `Yellow` in case we don't have a match (not 100% sure if we return the status in English language even on OS with other regional settings) or in case that a new `certificateStatus` is introduced.

**Validation:**
Validated in lab. Possible Pester unit test case.

**Kudos:**
To @FrankPlawetzki for providing feedback regarding this check.